### PR TITLE
implement alt-mode

### DIFF
--- a/Foreman/ProductionGraphView/Elements/BaseNodeElement.cs
+++ b/Foreman/ProductionGraphView/Elements/BaseNodeElement.cs
@@ -228,9 +228,21 @@ namespace Foreman
 			//highlight
 			if (Highlighted)
 				GraphicsStuff.FillRoundRect(trans.X - (Width / 2), trans.Y - (Height / 2), Width, Height, 8, graphics, selectionOverlayBrush);
+
+			if (graphViewer.InAltDisplayMode && graphViewer.ViewScale < 0.25)
+			{
+				Bitmap icon = this.GetAltDisplayIcon();
+				if (icon != null)
+				{
+					float iconSize = 32f / graphViewer.ViewScale;
+					graphics.DrawImage(this.GetAltDisplayIcon(), trans.X - (iconSize / 2), trans.Y - (iconSize / 2), iconSize, iconSize);
+				}
+			}
 		}
 
 		protected abstract void DetailsDraw(Graphics graphics, Point trans, bool simple); //draw the inside of the node.
+
+		protected abstract Bitmap GetAltDisplayIcon();
 
 		public override List<TooltipInfo> GetToolTips(Point graph_point)
 		{

--- a/Foreman/ProductionGraphView/Elements/ConsumerNodeElement.cs
+++ b/Foreman/ProductionGraphView/Elements/ConsumerNodeElement.cs
@@ -38,6 +38,11 @@ namespace Foreman
 			graphics.DrawString(DisplayedNode.RateType == RateType.Auto ? "Infinite Sink:" : "Required Output:", TitleFont, TextBrush, titleSlot, TitleFormat);
 			GraphicsStuff.DrawText(graphics, TextBrush, TextFormat, ItemName, BaseFont, textSlot);
 		}
+		
+		protected override Bitmap GetAltDisplayIcon()
+		{
+			return DisplayedNode.ConsumedItem.Icon;;
+		}
 
 		protected override List<TooltipInfo> GetMyToolTips(Point graph_point, bool exclusive)
 		{

--- a/Foreman/ProductionGraphView/Elements/PassthroughNodeElement.cs
+++ b/Foreman/ProductionGraphView/Elements/PassthroughNodeElement.cs
@@ -41,6 +41,11 @@ namespace Foreman
 				GraphicsStuff.DrawText(graphics, TextBrush, TextFormat, GraphicsStuff.DoubleToString(DisplayedNode.DesiredRate), BaseFont, textSlot);
 			}
 		}
+		
+		protected override Bitmap GetAltDisplayIcon()
+		{
+			return null;;
+		}
 
 		protected override List<TooltipInfo> GetMyToolTips(Point graph_point, bool exclusive)
 		{

--- a/Foreman/ProductionGraphView/Elements/RecipeNodeElement.cs
+++ b/Foreman/ProductionGraphView/Elements/RecipeNodeElement.cs
@@ -131,6 +131,11 @@ namespace Foreman
 				graphics.DrawEllipse(extraProductivityPen, trans.X - (Width / 2) - 1, trans.Y - (Height / 2) + 10, 6, 6);
 			}
 		}
+		
+		protected override Bitmap GetAltDisplayIcon()
+		{
+			return DisplayedNode.BaseRecipe.Icon;
+		}
 
 		protected override void AddRClickMenuOptions(bool nodeInSelection)
 		{

--- a/Foreman/ProductionGraphView/Elements/SupplierNodeElement.cs
+++ b/Foreman/ProductionGraphView/Elements/SupplierNodeElement.cs
@@ -38,6 +38,11 @@ namespace Foreman
 			graphics.DrawString(DisplayedNode.RateType == RateType.Auto ? "Infinite Source:" : "Exact Input:", TitleFont, TextBrush, titleSlot, TitleFormat);
 			GraphicsStuff.DrawText(graphics, TextBrush, TextFormat, ItemName, BaseFont, textSlot);
 		}
+		
+		protected override Bitmap GetAltDisplayIcon()
+		{
+			return DisplayedNode.SuppliedItem.Icon;;
+		}
 
 		protected override List<TooltipInfo> GetMyToolTips(Point graph_point, bool exclusive)
 		{

--- a/Foreman/ProductionGraphView/ProductionGraphViewer.cs
+++ b/Foreman/ProductionGraphView/ProductionGraphViewer.cs
@@ -44,6 +44,10 @@ namespace Foreman
 		public IReadOnlyDictionary<ReadOnlyNodeLink, LinkElement> LinkElementDictionary { get { return linkElementDictionary; } }
 
 		public IReadOnlyCollection<BaseNodeElement> SelectedNodes { get { return selectedNodes; } }
+		
+		public float ViewScale { get; private set; }
+
+		public bool InAltDisplayMode { get; private set; }
 
 		private const int minDragDiff = 30;
 		private const int minLinkWidth = 3;
@@ -67,7 +71,6 @@ namespace Foreman
 		private DragOperation currentDragOperation = DragOperation.None;
 
 		private Point ViewOffset;
-		private float ViewScale = 1f;
 		private Rectangle visibleGraphBounds;
 
 		private Rectangle SelectionZone;
@@ -809,6 +812,9 @@ namespace Foreman
 
 		private void ProductionGraphViewer_KeyDown(object sender, KeyEventArgs e)
 		{
+			if (e.Alt)
+				this.InAltDisplayMode = !this.InAltDisplayMode;
+
 			if (currentDragOperation == DragOperation.None)
 			{
 				if ((e.KeyCode == Keys.C || e.KeyCode == Keys.X) && (e.Modifiers & Keys.Control) == Keys.Control) //copy or cut


### PR DESCRIPTION
This PR implements alt-mode (as used in the game). The Alt keyboard key toggles it on/off. it will display an overlay icon on the zoomed out nodes, to easily visualize large graphs. This makes it easy for planning mega-bases, as the entire production graph is understandable when viewing the entire base.

* It does nothing when the user has zoomed in (> 0.25 scale).
* The icons scale up as the user further zooms out.

![image](https://user-images.githubusercontent.com/15987992/140685008-061e537e-34d4-478a-932d-13d82590194d.png)


