### PR TITLE
Fix issue where export can fail on mineable resources with no products.

### DIFF
--- a/Foreman/Mods/foremanexport_1.0.0/instrument-control - ee.lua
+++ b/Foreman/Mods/foremanexport_1.0.0/instrument-control - ee.lua
@@ -439,19 +439,21 @@ local function ExportResources()
 			tresource['name'] = resource.name
 
 			tresource['products'] = {}
-			for _, product in pairs(resource.mineable_properties.products) do
-				tproduct = {}
-				tproduct['name'] = product.name
-				tproduct['type'] = product.type
-
-				amount = (product.amount == nil) and ((product.amount_max + product.amount_min)/2) or product.amount
-				amount = amount * ( (product.probability == nil) and 1 or product.probability)
-				tproduct['amount'] = amount
-
-				if product.type == 'fluid' and product.temperate ~= nil then
-					tproduct['temperature'] = ProcessTemperature(product.temperature)
-				end
-				table.insert(tresource['products'], tproduct)
+			if resource.mineable_properties.products ~= nil then
+                for _, product in pairs(resource.mineable_properties.products) do
+                    tproduct = {}
+                    tproduct['name'] = product.name
+                    tproduct['type'] = product.type
+    
+                    amount = (product.amount == nil) and ((product.amount_max + product.amount_min)/2) or product.amount
+                    amount = amount * ( (product.probability == nil) and 1 or product.probability)
+                    tproduct['amount'] = amount
+    
+                    if product.type == 'fluid' and product.temperate ~= nil then
+                        tproduct['temperature'] = ProcessTemperature(product.temperature)
+                    end
+                    table.insert(tresource['products'], tproduct)
+                end
 			end
 
 			tresource['lid'] = '$'..localindex

--- a/Foreman/Mods/foremanexport_1.0.0/instrument-control - ee.lua
+++ b/Foreman/Mods/foremanexport_1.0.0/instrument-control - ee.lua
@@ -444,11 +444,11 @@ local function ExportResources()
                     tproduct = {}
                     tproduct['name'] = product.name
                     tproduct['type'] = product.type
-    
+                
                     amount = (product.amount == nil) and ((product.amount_max + product.amount_min)/2) or product.amount
                     amount = amount * ( (product.probability == nil) and 1 or product.probability)
                     tproduct['amount'] = amount
-    
+                
                     if product.type == 'fluid' and product.temperate ~= nil then
                         tproduct['temperature'] = ProcessTemperature(product.temperature)
                     end

--- a/Foreman/Mods/foremanexport_1.0.0/instrument-control - en.lua
+++ b/Foreman/Mods/foremanexport_1.0.0/instrument-control - en.lua
@@ -439,19 +439,21 @@ local function ExportResources()
 			tresource['name'] = resource.name
 
 			tresource['products'] = {}
-			for _, product in pairs(resource.mineable_properties.products) do
-				tproduct = {}
-				tproduct['name'] = product.name
-				tproduct['type'] = product.type
-
-				amount = (product.amount == nil) and ((product.amount_max + product.amount_min)/2) or product.amount
-				amount = amount * ( (product.probability == nil) and 1 or product.probability)
-				tproduct['amount'] = amount
-
-				if product.type == 'fluid' and product.temperate ~= nil then
-					tproduct['temperature'] = ProcessTemperature(product.temperature)
-				end
-				table.insert(tresource['products'], tproduct)
+			if resource.mineable_properties.products ~= nil then
+                for _, product in pairs(resource.mineable_properties.products) do
+                    tproduct = {}
+                    tproduct['name'] = product.name
+                    tproduct['type'] = product.type
+    
+                    amount = (product.amount == nil) and ((product.amount_max + product.amount_min)/2) or product.amount
+                    amount = amount * ( (product.probability == nil) and 1 or product.probability)
+                    tproduct['amount'] = amount
+    
+                    if product.type == 'fluid' and product.temperate ~= nil then
+                        tproduct['temperature'] = ProcessTemperature(product.temperature)
+                    end
+                    table.insert(tresource['products'], tproduct)
+                end
 			end
 
 			tresource['lid'] = '$'..localindex

--- a/Foreman/Mods/foremanexport_1.0.0/instrument-control - en.lua
+++ b/Foreman/Mods/foremanexport_1.0.0/instrument-control - en.lua
@@ -444,11 +444,11 @@ local function ExportResources()
                     tproduct = {}
                     tproduct['name'] = product.name
                     tproduct['type'] = product.type
-    
+                
                     amount = (product.amount == nil) and ((product.amount_max + product.amount_min)/2) or product.amount
                     amount = amount * ( (product.probability == nil) and 1 or product.probability)
                     tproduct['amount'] = amount
-    
+                
                     if product.type == 'fluid' and product.temperate ~= nil then
                         tproduct['temperature'] = ProcessTemperature(product.temperature)
                     end

--- a/Foreman/Mods/foremanexport_1.0.0/instrument-control - ne.lua
+++ b/Foreman/Mods/foremanexport_1.0.0/instrument-control - ne.lua
@@ -439,19 +439,21 @@ local function ExportResources()
 			tresource['name'] = resource.name
 
 			tresource['products'] = {}
-			for _, product in pairs(resource.mineable_properties.products) do
-				tproduct = {}
-				tproduct['name'] = product.name
-				tproduct['type'] = product.type
-
-				amount = (product.amount == nil) and ((product.amount_max + product.amount_min)/2) or product.amount
-				amount = amount * ( (product.probability == nil) and 1 or product.probability)
-				tproduct['amount'] = amount
-
-				if product.type == 'fluid' and product.temperate ~= nil then
-					tproduct['temperature'] = ProcessTemperature(product.temperature)
-				end
-				table.insert(tresource['products'], tproduct)
+			if resource.mineable_properties.products ~= nil then
+                for _, product in pairs(resource.mineable_properties.products) do
+                    tproduct = {}
+                    tproduct['name'] = product.name
+                    tproduct['type'] = product.type
+    
+                    amount = (product.amount == nil) and ((product.amount_max + product.amount_min)/2) or product.amount
+                    amount = amount * ( (product.probability == nil) and 1 or product.probability)
+                    tproduct['amount'] = amount
+    
+                    if product.type == 'fluid' and product.temperate ~= nil then
+                        tproduct['temperature'] = ProcessTemperature(product.temperature)
+                    end
+                    table.insert(tresource['products'], tproduct)
+                end
 			end
 
 			tresource['lid'] = '$'..localindex

--- a/Foreman/Mods/foremanexport_1.0.0/instrument-control - ne.lua
+++ b/Foreman/Mods/foremanexport_1.0.0/instrument-control - ne.lua
@@ -444,11 +444,11 @@ local function ExportResources()
                     tproduct = {}
                     tproduct['name'] = product.name
                     tproduct['type'] = product.type
-    
+                
                     amount = (product.amount == nil) and ((product.amount_max + product.amount_min)/2) or product.amount
                     amount = amount * ( (product.probability == nil) and 1 or product.probability)
                     tproduct['amount'] = amount
-    
+                
                     if product.type == 'fluid' and product.temperate ~= nil then
                         tproduct['temperature'] = ProcessTemperature(product.temperature)
                     end

--- a/Foreman/Mods/foremanexport_1.0.0/instrument-control - nn.lua
+++ b/Foreman/Mods/foremanexport_1.0.0/instrument-control - nn.lua
@@ -439,20 +439,22 @@ local function ExportResources()
 			tresource['name'] = resource.name
 
 			tresource['products'] = {}
-			for _, product in pairs(resource.mineable_properties.products) do
-				tproduct = {}
-				tproduct['name'] = product.name
-				tproduct['type'] = product.type
-
-				amount = (product.amount == nil) and ((product.amount_max + product.amount_min)/2) or product.amount
-				amount = amount * ( (product.probability == nil) and 1 or product.probability)
-				tproduct['amount'] = amount
-
-				if product.type == 'fluid' and product.temperate ~= nil then
-					tproduct['temperature'] = ProcessTemperature(product.temperature)
-				end
-				table.insert(tresource['products'], tproduct)
-			end
+			if resource.mineable_properties.products ~= nil then
+                for _, product in pairs(resource.mineable_properties.products) do
+                    tproduct = {}
+                    tproduct['name'] = product.name
+                    tproduct['type'] = product.type
+    
+                    amount = (product.amount == nil) and ((product.amount_max + product.amount_min)/2) or product.amount
+                    amount = amount * ( (product.probability == nil) and 1 or product.probability)
+                    tproduct['amount'] = amount
+    
+                    if product.type == 'fluid' and product.temperate ~= nil then
+                        tproduct['temperature'] = ProcessTemperature(product.temperature)
+                    end
+                    table.insert(tresource['products'], tproduct)
+                end
+            end
 
 			tresource['lid'] = '$'..localindex
 			ExportLocalisedString(resource.localised_name, localindex)

--- a/Foreman/Mods/foremanexport_1.0.0/instrument-control - nn.lua
+++ b/Foreman/Mods/foremanexport_1.0.0/instrument-control - nn.lua
@@ -444,11 +444,11 @@ local function ExportResources()
                     tproduct = {}
                     tproduct['name'] = product.name
                     tproduct['type'] = product.type
-    
+                
                     amount = (product.amount == nil) and ((product.amount_max + product.amount_min)/2) or product.amount
                     amount = amount * ( (product.probability == nil) and 1 or product.probability)
                     tproduct['amount'] = amount
-    
+                
                     if product.type == 'fluid' and product.temperate ~= nil then
                         tproduct['temperature'] = ProcessTemperature(product.temperature)
                     end


### PR DESCRIPTION
### Problem

I was playing the latest version of Seablock and trying to use Foreman to export the recipe/item list would fail with the "possible mod conflict" error.

Upon further inspection, the actual error was coming from the .lua code, saying that you can't pass `nil` in to `pairs` when exporting the products of a mineable resource. I assume this is something weird to do with Seablock and/or an overwritten recipe where it has set the products to empty. I wasn't sure how to debug the .lua further to figure out what item/recipe was causing it.

### Solution

I've wrapped the code that parses the products from mining in a nil check so it only tries that code when the property is set.

**Note:** I have no idea if this is the correct fix but it worked for me and everything seems okay in Foreman afterwards.