### PR TITLE
Round up in the launch product recipes when calculating input size

### DIFF
--- a/Foreman/DataCache/DataCache.cs
+++ b/Foreman/DataCache/DataCache.cs
@@ -1306,7 +1306,7 @@ namespace Foreman
 				if (amount != 0)
 				{
 					if (inputSize * amount > product.StackSize)
-						inputSize = (int)(product.StackSize / amount);
+						inputSize = (int)Math.Ceiling(product.StackSize / amount);
 
 					amount = inputSize * amount;
 

--- a/Foreman/DataCache/PresetProcessor.cs
+++ b/Foreman/DataCache/PresetProcessor.cs
@@ -282,7 +282,7 @@ namespace Foreman
 						double amount = (double)productJToken["amount"];
 						int productStack = (int)(jsonData["items"].First(t => (string)t["name"] == (string)productJToken["name"])["stack"]?? 1);
 						if (amount != 0 && inputSize * amount > productStack)
-							inputSize = (int)(productStack / amount);
+							inputSize = (int)Math.Ceiling(productStack / amount);
 					}
 					foreach (var productJToken in objJToken["launch_products"])
 					{


### PR DESCRIPTION
This prevents it from being set to zero and resulting in invalid recipe. Fixes #76

In Space Exploration for some reason the launch of one satellite produces 100 "satellite telemetry data", even though its stack size is 50. This trips up the computation setting the `inputSize` to 0.