### PR TITLE
Fix uncaught exception if a graph has no beacons in use.

### DIFF
--- a/Foreman/Forms/GraphSummaryForm.cs
+++ b/Foreman/Forms/GraphSummaryForm.cs
@@ -102,7 +102,7 @@ namespace Foreman
 			LoadUnfilteredSelectedAssemblerList(nodes.Where(n => n is ReadOnlyRecipeNode rNode && (rNode.SelectedAssembler.Assembler.EntityType == EntityType.Miner || rNode.SelectedAssembler.Assembler.EntityType == EntityType.OffshorePump)).Select(n => (ReadOnlyRecipeNode)n), unfilteredMinerList);
 			LoadUnfilteredSelectedAssemblerList(nodes.Where(n => n is ReadOnlyRecipeNode rNode && (rNode.SelectedAssembler.Assembler.EntityType == EntityType.Boiler || rNode.SelectedAssembler.Assembler.EntityType == EntityType.BurnerGenerator || rNode.SelectedAssembler.Assembler.EntityType == EntityType.Generator || rNode.SelectedAssembler.Assembler.EntityType == EntityType.Reactor)).Select(n => (ReadOnlyRecipeNode)n), unfilteredPowerList);
 
-			LoadUnfilteredBeaconList(nodes.Where(n => n is ReadOnlyRecipeNode rNode && rNode.SelectedBeacon != null).Select(n => (ReadOnlyRecipeNode)n), unfilteredBeaconList);
+			LoadUnfilteredBeaconList(nodes.Where(n => n is ReadOnlyRecipeNode rNode && rNode.SelectedBeacon).Select(n => (ReadOnlyRecipeNode)n), unfilteredBeaconList);
 
 			LoadUnfilteredItemLists(nodes, links, false, unfilteredItemsList);
 			LoadUnfilteredItemLists(nodes, links, true, unfilteredFluidsList);

--- a/Foreman/Models/Nodes/RecipeNode.cs
+++ b/Foreman/Models/Nodes/RecipeNode.cs
@@ -163,7 +163,7 @@ namespace Foreman
 			beaconModules = new List<ModuleQualityPair>();
 
 			SelectedAssembler = new AssemblerQualityPair(recipe.Recipe.Assemblers.First(), assemblerQuality); //everything here works under the assumption that assember isnt null.
-			SelectedBeacon = new BeaconQualityPair(null,null);
+			SelectedBeacon = new BeaconQualityPair("null here because no beacon is defined yet");
 			NeighbourCount = 0;
 
 			BeaconCount = 0;
@@ -208,7 +208,7 @@ namespace Foreman
 			if(AssemblerModules.Any(m => m.Quality.IsMissing))
 				ErrorSet |= Errors.AModuleQualityIsMissing;
 
-			if (SelectedBeacon.Beacon != null)
+			if (SelectedBeacon)
 			{
 				if (SelectedBeacon.Beacon.IsMissing)
 					ErrorSet |= Errors.BeaconIsMissing;
@@ -262,7 +262,7 @@ namespace Foreman
 			if (AssemblerModules.Any(m => !m.Quality.Enabled))
 				WarningSet |= Warnings.AModulesQualityIsDisabled;
 
-			if (SelectedBeacon.Beacon != null)
+			if (SelectedBeacon)
 			{
 				if (!SelectedBeacon.Beacon.Enabled)
 					WarningSet |= Warnings.BeaconIsDisabled;
@@ -543,7 +543,7 @@ namespace Foreman
 			if (FuelRemains != null)
 				info.AddValue("Burnt", FuelRemains.Name);
 
-			if (SelectedBeacon.Beacon != null)
+			if (SelectedBeacon)
 			{
 				info.AddValue("Beacon", SelectedBeacon.Beacon.Name);
 				info.AddValue("BeaconQuality", SelectedBeacon.Quality.Name);
@@ -827,14 +827,14 @@ namespace Foreman
 
 		public int GetTotalBeacons()
 		{
-			if (MyNode.SelectedBeacon.Beacon == null)
+			if (!MyNode.SelectedBeacon)
 				return 0;
 			return (int)Math.Ceiling(((int)(MyNode.ActualSetValue + 0.8) * BeaconsPerAssembler) + BeaconsConst); //assume 0.2 assemblers (or more) is enough to warrant an extra 'beacons per assembler' row
 		}
 
 		public double GetTotalBeaconElectricalConsumption() // J/sec (W)
 		{
-			if (MyNode.SelectedBeacon.Beacon == null)
+			if (!MyNode.SelectedBeacon)
 				return 0;
 			return GetTotalBeacons() * GetBeaconEnergyConsumption();
 		}
@@ -1042,7 +1042,7 @@ namespace Foreman
 
 		public void ClearBeacon()
 		{
-			MyNode.SelectedBeacon = new BeaconQualityPair(null, null);
+			MyNode.SelectedBeacon = new BeaconQualityPair("clear beacons with nulled object");
             MyNode.BeaconModulesClear();
             MyNode.BeaconCount = 0;
             MyNode.BeaconsPerAssembler = 0;
@@ -1052,7 +1052,7 @@ namespace Foreman
 
 		public void SetBeacon(BeaconQualityPair beacon)
 		{
-			if(beacon.Beacon == null) { ClearBeacon(); return; } //shouldnt be called - but whatever
+			if(!beacon) { ClearBeacon(); return; } //shouldnt be called - but whatever
 
 			MyNode.SelectedBeacon = beacon;
 			//check for invalid modules

--- a/Foreman/Models/ProductionGraph.cs
+++ b/Foreman/Models/ProductionGraph.cs
@@ -450,7 +450,7 @@ namespace Foreman
 
 						includedAssemblers.Add(rnode.SelectedAssembler.Assembler.Name);
 
-						if (rnode.SelectedBeacon.Beacon != null)
+						if (rnode.SelectedBeacon)
 							includedBeacons.Add(rnode.SelectedBeacon.Beacon.Name);
 
 						includedModules.UnionWith(rnode.AssemblerModules.Select(m => m.Module.Name));
@@ -459,7 +459,7 @@ namespace Foreman
 						includedQualities.Add(new KeyValuePair<string, int>(rnode.BaseRecipe.Quality.Name, rnode.BaseRecipe.Quality.Level));
 						includedQualities.Add(new KeyValuePair<string, int>(rnode.SelectedAssembler.Quality.Name, rnode.SelectedAssembler.Quality.Level));
 
-						if (rnode.SelectedBeacon.Beacon != null)
+						if (rnode.SelectedBeacon)
 							includedQualities.Add(new KeyValuePair<string, int>(rnode.BaseRecipe.Quality.Name, rnode.BaseRecipe.Quality.Level));
 
 						includedQualities.UnionWith(rnode.AssemblerModules.Select(m => new KeyValuePair<string, int>(m.Quality.Name, m.Quality.Level)));

--- a/Foreman/Models/QualityPairs.cs
+++ b/Foreman/Models/QualityPairs.cs
@@ -146,13 +146,18 @@ namespace Foreman
         public readonly Beacon Beacon;
         public readonly Quality Quality;
 
+        public BeaconQualityPair(string comment) {
+            Beacon = null;
+            Quality = null;
+        }
+
         public BeaconQualityPair(Beacon beacon, Quality quality)
         {
+            if (beacon == null || quality == null)
+                throw new NullReferenceException("null error - Beacon: " + nameof(Beacon) + " Quality: " + nameof(Quality));
+
             Beacon = beacon;
             Quality = quality;
-
-            if (Beacon != null && Quality == null)
-                Trace.Fail(string.Format("Attempted to create Beacon quality pair with Beacon {0} and no quality!", Beacon));
         }
 
         public override bool Equals(object obj) => obj is BeaconQualityPair other && this.Equals(other);
@@ -161,6 +166,7 @@ namespace Foreman
         public static bool operator ==(BeaconQualityPair lhs, BeaconQualityPair rhs) => lhs.Equals(rhs);
         public static bool operator !=(BeaconQualityPair lhs, BeaconQualityPair rhs) => !(lhs == rhs);
         public override string ToString() { return Beacon.ToString() + " (" + Quality.ToString() + ")"; }
+        public static implicit operator bool(BeaconQualityPair bp) => bp != null && bp.Beacon != null && bp.Quality != null;
 
         public string FriendlyName
         {


### PR DESCRIPTION
The "Show Graph Summary" feature would fail entirely if your graph does not use any beacons. We now implement an operator bool on the BeaconQualityPair struct and check it directly since the type should be responsible for knowing whether it's in a valid state or not.

All callsites that previously initialized the struct with null parameters simply call a separate constructor with a documentory comment.