### PR TITLE
Fix recipe not being recomputed after changing neighbour bonus.

### DIFF
--- a/Foreman/Models/Nodes/RecipeNode.cs
+++ b/Foreman/Models/Nodes/RecipeNode.cs
@@ -952,7 +952,14 @@ namespace Foreman
 
 		public void SetPriority(bool lowPriority) { MyNode.LowPriority = lowPriority; MyNode.UpdateState(); }
 
-		public void SetNeighbourCount(double count) { if (MyNode.NeighbourCount != count) MyNode.NeighbourCount = count; }
+		public void SetNeighbourCount(double count)
+		{
+			if (MyNode.NeighbourCount != count)
+			{
+				MyNode.NeighbourCount = count;
+				MyNode.UpdateInputsAndOutputs(true);
+			}
+		}
 		public void SetExtraProductivityBonus(double bonus) { if (MyNode.ExtraProductivityBonus != bonus) MyNode.ExtraProductivityBonus = bonus; }
 		public void SetBeaconCount(double count) { if (MyNode.BeaconCount != count) MyNode.BeaconCount = count; }
 		public void SetBeaconsPerAssembler(double beacons) { if (MyNode.BeaconsPerAssembler != beacons) MyNode.BeaconsPerAssembler = beacons; }


### PR DESCRIPTION
When a user changes the neighbour count - such as on a Nuclear Reactor, the recipe was not recomputing. We now invoke an update if the count is changed which results in the correct values being displayed.