### PR TITLE
Fix direct asteroid recipes

### DIFF
--- a/Foreman/Presets/Factorio 2.0 Space Age.pjson
+++ b/Foreman/Presets/Factorio 2.0 Space Age.pjson
@@ -21407,8 +21407,8 @@
         {
           "name": "metallic-asteroid-chunk",
           "type": "item",
-          "amount": 0.2,
-          "p_amount": 0.2
+          "amount": 0.05,
+          "p_amount": 0.05
         }
       ],
       "localised_name": "Metallic asteroid crushing"
@@ -21496,8 +21496,8 @@
         {
           "name": "carbonic-asteroid-chunk",
           "type": "item",
-          "amount": 0.2,
-          "p_amount": 0.2
+          "amount": 0.05,
+          "p_amount": 0.05
         }
       ],
       "localised_name": "Carbonic asteroid crushing"
@@ -21585,8 +21585,8 @@
         {
           "name": "oxide-asteroid-chunk",
           "type": "item",
-          "amount": 0.2,
-          "p_amount": 0.2
+          "amount": 0.05,
+          "p_amount": 0.05
         }
       ],
       "localised_name": "Oxide asteroid crushing"


### PR DESCRIPTION
The yield isn't 20% for an asteroid chunk, but 5%. You only reach 20% with +300% productivity. And before this commit, the maximum for the calculator was 80% after all productivity bonusses.