### PR TITLE
Show net power in Graph summary, fix power calculation bug.

### DIFF
--- a/Foreman/DataCache/Loading/EntityDataLoader.cs
+++ b/Foreman/DataCache/Loading/EntityDataLoader.cs
@@ -206,7 +206,7 @@ namespace Foreman {
 
             //energy consumption
             entity.energyDrain = PresetJson.GetDouble(objJsonNode, "drain") ?? 0; //seconds
-            foreach (JsonNode speedToken in PresetJson.EnumerateArray(objJsonNode, "q_energy_production"))
+            foreach (JsonNode speedToken in PresetJson.EnumerateArray(objJsonNode, "q_max_energy_usage"))
                 if (PresetJson.GetString(speedToken, "quality") is string quality && PresetJson.GetDouble(speedToken, "value") is double value)
                     entity.energyConsumption.Add(_store.Qualities[quality], value);
 

--- a/Foreman/Forms/GraphSummaryForm.Designer.cs
+++ b/Foreman/Forms/GraphSummaryForm.Designer.cs
@@ -61,6 +61,7 @@ namespace Foreman
 			this.BeaconsHeaderPower = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
 			this.PowerConsumptionLabel = new System.Windows.Forms.Label();
 			this.PowerProductionLabel = new System.Windows.Forms.Label();
+			this.PowerNetLabel = new System.Windows.Forms.Label();
 			this.BuildingsExportButton = new System.Windows.Forms.Button();
 			this.ItemsTabPage = new System.Windows.Forms.TabPage();
 			this.ItemsTable = new System.Windows.Forms.TableLayoutPanel();
@@ -460,6 +461,17 @@ namespace Foreman
 			this.PowerProductionLabel.Size = new System.Drawing.Size(110, 15);
 			this.PowerProductionLabel.TabIndex = 32;
 			this.PowerProductionLabel.Text = "Power Production: ";
+			// 
+			// PowerNetLabel
+			// 
+			this.PowerNetLabel.AutoSize = true;
+			this.PowerNetLabel.Location = new System.Drawing.Point(482, 5);
+			this.PowerNetLabel.Margin = new System.Windows.Forms.Padding(7, 5, 15, 5);
+			this.PowerNetLabel.Name = "PowerNetLabel";
+			this.PowerNetLabel.Size = new System.Drawing.Size(70, 15);
+			this.PowerNetLabel.TabIndex = 35;
+			this.PowerNetLabel.Text = "Net Power: ";
+			this.PowerNetLabel.Visible = false;
 			// 
 			// BuildingsExportButton
 			// 
@@ -1058,8 +1070,9 @@ namespace Foreman
 			// 
 			this.tableLayoutPanel2.AutoSize = true;
 			this.tableLayoutPanel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.tableLayoutPanel2.ColumnCount = 4;
+			this.tableLayoutPanel2.ColumnCount = 5;
 			this.BuildingsTable.SetColumnSpan(this.tableLayoutPanel2, 2);
+			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
@@ -1068,6 +1081,7 @@ namespace Foreman
 			this.tableLayoutPanel2.Controls.Add(this.BuildingCountLabel, 0, 0);
 			this.tableLayoutPanel2.Controls.Add(this.PowerConsumptionLabel, 2, 0);
 			this.tableLayoutPanel2.Controls.Add(this.PowerProductionLabel, 3, 0);
+			this.tableLayoutPanel2.Controls.Add(this.PowerNetLabel, 4, 0);
 			this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.tableLayoutPanel2.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F);
 			this.tableLayoutPanel2.Location = new System.Drawing.Point(44, 3);
@@ -1176,6 +1190,7 @@ namespace Foreman
 		private System.Windows.Forms.ColumnHeader BeaconsHeaderName;
 		private System.Windows.Forms.Label PowerConsumptionLabel;
 		private System.Windows.Forms.Label PowerProductionLabel;
+		private System.Windows.Forms.Label PowerNetLabel;
 		private System.Windows.Forms.TableLayoutPanel ItemsTable;
 		private System.Windows.Forms.Label label1;
 		private System.Windows.Forms.TabControl ItemsTabControl;

--- a/Foreman/Forms/GraphSummaryForm.cs
+++ b/Foreman/Forms/GraphSummaryForm.cs
@@ -123,6 +123,10 @@ namespace Foreman {
             double powerProduction = recipeNodes.Sum(n => n.GetTotalGeneratorElectricalProduction());
             PowerConsumptionLabel.Text += GraphicsStuff.DoubleToEnergy(powerConsumption, "W");
             PowerProductionLabel.Text += GraphicsStuff.DoubleToEnergy(powerProduction, "W");
+            if (powerConsumption > 0 && powerProduction > 0) {
+                PowerNetLabel.Visible = true;
+                PowerNetLabel.Text += GraphicsStuff.DoubleToEnergy(powerProduction - powerConsumption, "W");
+            }
 
             //update filtered
             UpdateFilteredBuildingLists();

--- a/Foreman/Forms/MainForm.Designer.cs
+++ b/Foreman/Forms/MainForm.Designer.cs
@@ -566,7 +566,7 @@
             this.MinimumSize = new System.Drawing.Size(950, 400);
             this.Name = "MainForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Foreman 2.2";
+            this.Text = "Foreman 2";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);
             this.Load += new System.EventHandler(this.MainForm_Load);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MainForm_KeyDown);

--- a/ForemanTest/DataCacheTests.cs
+++ b/ForemanTest/DataCacheTests.cs
@@ -209,6 +209,20 @@ namespace ForemanTest {
         }
 
         [TestMethod]
+        public async Task LoadAllData_Vanilla_NuclearReactorAndSteamTurbineEnergyValues() {
+            var cache = await VanillaDataCacheFixture.GetLoadedAsync();
+            Assert.IsNotNull(cache.DefaultQuality);
+            var quality = cache.DefaultQuality;
+            var reactor = cache.Assemblers["nuclear-reactor"];
+            var turbine = cache.Assemblers["steam-turbine"];
+
+            Assert.AreEqual(40_000_000, reactor.GetEnergyConsumption(quality));
+            Assert.AreEqual(40, reactor.GetSpeed(quality), 1e-6);
+            Assert.AreEqual(5_820_000, turbine.GetEnergyProduction(quality));
+            Assert.AreEqual(0, turbine.GetEnergyConsumption(quality));
+        }
+
+        [TestMethod]
         public async Task LoadAllData_Vanilla_CollectionsHaveExpectedScale() {
             var cache = await VanillaDataCacheFixture.GetLoadedAsync();
             Assert.IsTrue(cache.Items.Count > 100, $"Vanilla item count was {cache.Items.Count}.");


### PR DESCRIPTION
If your graph contains both power producers and consumers, we now display your net power surplus/deficit in the Graph Summary view.

Additionally, a bug was uncovered during testing that revealed we were referencing the wrong field when checking energy consumers. This has been fixed and a test added.

Closes #133