### PR TITLE
Fix launch recipes and calculation.

### DIFF
--- a/Foreman/DataCache/Loading/PresetDataLoader.cs
+++ b/Foreman/DataCache/Loading/PresetDataLoader.cs
@@ -566,30 +566,30 @@ namespace Foreman {
             recipe.Time = 1; //placeholder really...
 
             //process products - have to calculate what the maximum input size of the launch item is so as not to waste any products (ex: you can launch 2000 science packs, but you will only get 100 fish. so input size must be set to 100 -> 100 science packs to 100 fish)
-            int inputSize = launchItem.StackSize;
-            Dictionary<ItemPrototype, double> products = new Dictionary<ItemPrototype, double>();
+            double inputSize = launchItem.StackSize;
+            Dictionary<ItemPrototype, double> amountPerLaunchItem = new Dictionary<ItemPrototype, double>();
             Dictionary<ItemPrototype, double> productTemp = new Dictionary<ItemPrototype, double>();
-            foreach (JsonNode productJsonNode in PresetJson.EnumerateArray(objJsonNode, "launch_products")) {
-                if (PresetJson.GetString(productJsonNode, "name") is not string prodName)
+            foreach (JsonNode productJsonNode in PresetJson.EnumerateArray(objJsonNode, "rocket_launch_products")) {
+                if (PresetJson.GetString(productJsonNode, "name") is not string prodName || !_store.Items.TryGetValue(prodName, out Item? productItem))
                     continue;
-                ItemPrototype product = (ItemPrototype)_store.Items[prodName];
+                ItemPrototype product = (ItemPrototype)productItem;
                 double amount = PresetJson.GetDouble(productJsonNode, "amount") ?? default;
-                if (amount != 0) {
-                    if (inputSize * amount > product.StackSize)
-                        inputSize = (int)(product.StackSize / amount);
+                if (amount == 0)
+                    continue;
 
-                    amount = inputSize * amount;
+                if (inputSize * amount > product.StackSize)
+                    inputSize = Math.Floor(product.StackSize / amount);
 
-                    if (PresetJson.GetString(productJsonNode, "type") == "fluid")
-                        productTemp.Add(product, PresetJson.GetDouble(productJsonNode, "temperature") ?? ((FluidPrototype)product).DefaultTemperature);
-                    products.Add(product, amount);
+                amountPerLaunchItem.Add(product, amount);
 
-                    product.productionRecipes.Add(recipe);
-                    recipe.SetIconAndColor(new IconColorPair(product.Icon, Color.DarkGray));
-                }
+                if (PresetJson.GetString(productJsonNode, "type") == "fluid")
+                    productTemp.Add(product, PresetJson.GetDouble(productJsonNode, "temperature") ?? ((FluidPrototype)product).DefaultTemperature);
+
+                product.productionRecipes.Add(recipe);
+                recipe.SetIconAndColor(new IconColorPair(product.Icon, Color.DarkGray));
             }
-            foreach (ItemPrototype product in products.Keys)
-                recipe.InternalOneWayAddProduct(product, inputSize * products[product], 0, productTemp.ContainsKey(product) ? productTemp[product] : double.NaN);
+            foreach (var (product, amount) in amountPerLaunchItem)
+                recipe.InternalOneWayAddProduct(product, inputSize * amount, 0, productTemp.TryGetValue(product, out double temp) ? temp : double.NaN);
 
             recipe.InternalOneWayAddIngredient(launchItem, inputSize);
             launchItem.consumptionRecipes.Add(recipe);

--- a/Foreman/DataCache/PresetProcessor.cs
+++ b/Foreman/DataCache/PresetProcessor.cs
@@ -168,19 +168,22 @@ namespace Foreman {
 
             //process launch product recipes
             if (presetItems.Contains("rocket-part") && presetRecipes.ContainsKey("rocket-part") && presetEntities.Contains("rocket-silo")) {
-                foreach (JsonNode objJsonNode in PresetJson.EnumerateArray(jsonData, "items").Concat(PresetJson.EnumerateArray(jsonData, "fluids")).Where(t => PresetJson.GetNode(t, "launch_products") is not null)) {
+                foreach (JsonNode objJsonNode in PresetJson.EnumerateArray(jsonData, "items").Concat(PresetJson.EnumerateArray(jsonData, "fluids")).Where(t => PresetJson.GetNode(t, "rocket_launch_products") is not null)) {
                     if (PresetJson.GetString(objJsonNode, "name") is not string name)
                         continue;
                     RecipeShort recipe = new RecipeShort(string.Format("§§r:rl:launch-{0}", name));
 
-                    int inputSize = PresetJson.GetInt32(objJsonNode, "stack") ?? default;
-                    foreach (JsonNode productJsonNode in PresetJson.EnumerateArray(objJsonNode, "launch_products")) {
+                    double inputSize = PresetJson.GetInt32(objJsonNode, "stack_size") ?? default;
+                    foreach (JsonNode productJsonNode in PresetJson.EnumerateArray(objJsonNode, "rocket_launch_products")) {
                         double amount = PresetJson.GetDouble(productJsonNode, "amount") ?? default;
-                        int productStack = PresetJson.GetInt32(PresetJson.EnumerateArray(jsonData, "items").FirstOrDefault(t => PresetJson.GetString(t, "name") == PresetJson.GetString(productJsonNode, "name")), "stack") ?? 1;
-                        if (amount != 0 && inputSize * amount > productStack)
-                            inputSize = (int)(productStack / amount);
+                        if (amount == 0 || PresetJson.GetString(productJsonNode, "name") is not string prodName)
+                            continue;
+                        JsonNode? productItemNode = PresetJson.EnumerateArray(jsonData, "items").FirstOrDefault(t => PresetJson.GetString(t, "name") == prodName);
+                        double productStack = PresetJson.GetInt32(productItemNode, "stack_size") ?? 1;
+                        if (inputSize * amount > productStack)
+                            inputSize = Math.Floor(productStack / amount);
                     }
-                    foreach (JsonNode productJsonNode in PresetJson.EnumerateArray(objJsonNode, "launch_products")) {
+                    foreach (JsonNode productJsonNode in PresetJson.EnumerateArray(objJsonNode, "rocket_launch_products")) {
                         double amount = PresetJson.GetDouble(productJsonNode, "amount") ?? default;
                         if (amount != 0 && PresetJson.GetString(productJsonNode, "name") is string prodName)
                             recipe.Products.Add(prodName, amount * inputSize);

--- a/ForemanTest/DataCacheTests.cs
+++ b/ForemanTest/DataCacheTests.cs
@@ -413,6 +413,20 @@ namespace ForemanTest {
         }
 
         [TestMethod]
+        public async Task LoadAllData_Vanilla_SatelliteRocketLaunchProductsAndIngredients() {
+            var cache = await VanillaDataCacheFixture.GetLoadedAsync();
+            Assert.IsTrue(cache.Recipes.TryGetValue("§§r:rl:launch-satellite", out Recipe? launchRecipe));
+            Assert.IsNotNull(launchRecipe);
+            Assert.IsTrue(cache.Items.TryGetValue("satellite", out Item? satellite));
+            Assert.IsTrue(cache.Items.TryGetValue("space-science-pack", out Item? spaceScience));
+            Assert.IsTrue(cache.Items.TryGetValue("rocket-part", out Item? rocketPart));
+
+            Assert.AreEqual(1, launchRecipe.IngredientSet[satellite]);
+            Assert.AreEqual(100, launchRecipe.IngredientSet[rocketPart]);
+            Assert.AreEqual(1000, launchRecipe.ProductSet[spaceScience]);
+        }
+
+        [TestMethod]
         public async Task LoadAllData_Vanilla_ProductivityModuleLinkedToCraftingRecipes() {
             var cache = await VanillaDataCacheFixture.GetLoadedAsync();
             Assert.IsTrue(cache.Modules.ContainsKey("productivity-module-3"));


### PR DESCRIPTION
We were using the wrong key for items returned via rocket launch. Additionally, in order to ensure accurate calculation, we retain a double instead of using an int.

A test has been added to validate behaviour.

Closes #76