### PR TITLE
Implement node autoconnect button

### DIFF
--- a/Foreman/Forms/MainForm.Designer.cs
+++ b/Foreman/Forms/MainForm.Designer.cs
@@ -42,6 +42,7 @@
             this.ImportGraphButton = new System.Windows.Forms.Button();
             this.NewGraphButton = new System.Windows.Forms.Button();
             this.LoadGraphButton = new System.Windows.Forms.Button();
+            this.AutoconnectButton = new System.Windows.Forms.Button();
             this.SaveAsGraphButton = new System.Windows.Forms.Button();
             this.GridLinesGroupBox = new System.Windows.Forms.GroupBox();
             this.GridlinesTable = new System.Windows.Forms.TableLayoutPanel();
@@ -148,6 +149,7 @@
             this.MenuButtonsTable.Controls.Add(this.ImportGraphButton, 1, 0);
             this.MenuButtonsTable.Controls.Add(this.NewGraphButton, 0, 0);
             this.MenuButtonsTable.Controls.Add(this.LoadGraphButton, 0, 3);
+            this.MenuButtonsTable.Controls.Add(this.AutoconnectButton, 1, 3);
             this.MenuButtonsTable.Controls.Add(this.SaveAsGraphButton, 0, 2);
             this.MenuButtonsTable.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MenuButtonsTable.Location = new System.Drawing.Point(3, 7);
@@ -289,6 +291,20 @@
             this.LoadGraphButton.Text = "Load";
             this.LoadGraphButton.UseVisualStyleBackColor = true;
             this.LoadGraphButton.Click += new System.EventHandler(this.LoadGraphButton_Click);
+            // 
+            // AutoconnectButton
+            // 
+            this.AutoconnectButton.AutoSize = true;
+            this.AutoconnectButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.AutoconnectButton.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.AutoconnectButton.Location = new System.Drawing.Point(77, 92);
+            this.AutoconnectButton.Margin = new System.Windows.Forms.Padding(2);
+            this.AutoconnectButton.Name = "AutoconnectButton";
+            this.AutoconnectButton.Size = new System.Drawing.Size(83, 26);
+            this.AutoconnectButton.TabIndex = 14;
+            this.AutoconnectButton.Text = "Autoconnect";
+            this.AutoconnectButton.UseVisualStyleBackColor = true;
+            this.AutoconnectButton.Click += new System.EventHandler(this.AutoconnectButton_Click);
             // 
             // SaveAsGraphButton
             // 
@@ -592,6 +608,7 @@
         private System.Windows.Forms.TableLayoutPanel MainLayoutPanel;
         private System.Windows.Forms.Button SaveAsGraphButton;
         private System.Windows.Forms.Button LoadGraphButton;
+        private System.Windows.Forms.Button AutoconnectButton;
         private System.Windows.Forms.Button NewGraphButton;
         private System.Windows.Forms.Button EnableDisableButton;
         private System.Windows.Forms.Button ExportImageButton;

--- a/Foreman/Forms/MainForm.cs
+++ b/Foreman/Forms/MainForm.cs
@@ -599,6 +599,10 @@ namespace Foreman {
             GraphViewer.AlignSelected();
         }
 
+        private void AutoconnectButton_Click(object? sender, EventArgs e) {
+            GraphViewer.AutoconnectDisconnectedInputs();
+        }
+
         private void GraphViewer_KeyDown(object? sender, KeyEventArgs e) {
             if (e.KeyCode == Keys.Space) {
                 GraphViewer.Grid.ShowGrid = !GraphViewer.Grid.ShowGrid;

--- a/Foreman/Graph/GraphAutoconnect.cs
+++ b/Foreman/Graph/GraphAutoconnect.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+
+namespace Foreman.Graph {
+    /// <summary>Connects unlinked node inputs to the nearest compatible output on another node.</summary>
+    public static class GraphAutoconnect {
+        public static int ConnectDisconnectedInputs(ProductionGraphSession session) {
+            if (session is null)
+                throw new ArgumentNullException(nameof(session));
+
+            IReadOnlyList<INodeViewModel> nodes = session.View.Nodes;
+            var suppliersByItem = new Dictionary<ItemQualityPair, List<NodeId>>();
+
+            foreach (INodeViewModel node in nodes) {
+                foreach (ItemQualityPair output in node.Outputs) {
+                    if (!suppliersByItem.TryGetValue(output, out List<NodeId>? supplierIds))
+                        suppliersByItem[output] = supplierIds = new List<NodeId>();
+                    supplierIds.Add(node.Id);
+                }
+            }
+
+            int linksCreated = 0;
+            foreach (INodeViewModel consumer in nodes) {
+                foreach (ItemQualityPair input in consumer.Inputs
+            .Where(input => !consumer.InputLinks.Any(link => link.Item == input))) {
+                    if (!suppliersByItem.TryGetValue(input, out List<NodeId>? suppliers))
+                        continue;
+
+                    NodeId supplierId = suppliers
+                        .Where(id => id != consumer.Id)
+                        .OrderBy(id => ManhattanDistance(session, id, consumer.Id))
+                        .FirstOrDefault();
+
+                    if (!supplierId.IsValid)
+                        continue;
+
+                    session.Editor.CreateLink(supplierId, consumer.Id, input);
+                    linksCreated++;
+                }
+            }
+
+            if (linksCreated > 0)
+                session.Graph.UpdateNodeValues();
+
+            return linksCreated;
+        }
+
+        private static int ManhattanDistance(ProductionGraphSession session, NodeId a, NodeId b) {
+            if (!session.View.TryGetNode(a, out INodeViewModel? nodeA) || nodeA is null)
+                return int.MaxValue;
+            if (!session.View.TryGetNode(b, out INodeViewModel? nodeB) || nodeB is null)
+                return int.MaxValue;
+            return Math.Abs(nodeA.Location.X - nodeB.Location.X) + Math.Abs(nodeA.Location.Y - nodeB.Location.Y);
+        }
+    }
+}

--- a/Foreman/ProductionGraphView/ProductionGraphViewer.cs
+++ b/Foreman/ProductionGraphView/ProductionGraphViewer.cs
@@ -452,6 +452,15 @@ namespace Foreman {
             Invalidate();
         }
 
+        public int AutoconnectDisconnectedInputs() {
+            int linksCreated = GraphAutoconnect.ConnectDisconnectedInputs(Session);
+            if (linksCreated > 0) {
+                Graph.UpdateNodeStates(false);
+                Invalidate();
+            }
+            return linksCreated;
+        }
+
         public void TryDeleteSelectedNodes() {
             bool proceed = true;
             if (selectedNodes.Count > 10)

--- a/ForemanTest/Graph/GraphAutoconnectTests.cs
+++ b/ForemanTest/Graph/GraphAutoconnectTests.cs
@@ -1,0 +1,64 @@
+﻿using Foreman;
+using Foreman.Graph;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace ForemanTest.Graph {
+    [TestClass]
+    public class GraphAutoconnectTests {
+        [TestMethod]
+        public void ConnectDisconnectedInputs_LinksSupplierToConsumer() {
+            var ctx = GraphSessionTestHelper.CreateContext();
+            var graph = ctx.NewGraph();
+            var session = GraphSessionTestHelper.AttachSession(graph);
+
+            ItemQualityPair plate = ctx.Item("plate");
+            session.Editor.CreateSupplierNode(plate, new System.Drawing.Point(0, 0));
+            NodeId consumerId = session.Editor.CreateConsumerNode(plate, new System.Drawing.Point(100, 0));
+
+            int created = GraphAutoconnect.ConnectDisconnectedInputs(session);
+
+            Assert.AreEqual(1, created);
+            session.View.TryGetNode(consumerId, out INodeViewModel? consumer);
+            Assert.IsNotNull(consumer);
+            Assert.IsTrue(consumer.InputLinks.Any(link => link.Item == plate));
+            Assert.AreEqual(1, graph.NodeLinks.Count());
+        }
+
+        [TestMethod]
+        public void ConnectDisconnectedInputs_DoesNotSelfConnectPassthrough() {
+            var ctx = GraphSessionTestHelper.CreateContext();
+            var graph = ctx.NewGraph();
+            var session = GraphSessionTestHelper.AttachSession(graph);
+
+            ItemQualityPair item = ctx.Item("wire");
+            session.Editor.CreatePassthroughNode(item, new System.Drawing.Point(0, 0));
+
+            int created = GraphAutoconnect.ConnectDisconnectedInputs(session);
+
+            Assert.AreEqual(0, created);
+            Assert.AreEqual(0, graph.NodeLinks.Count());
+        }
+
+        [TestMethod]
+        public void ConnectDisconnectedInputs_PrefersNearestSupplier() {
+            var ctx = GraphSessionTestHelper.CreateContext();
+            var graph = ctx.NewGraph();
+            var session = GraphSessionTestHelper.AttachSession(graph);
+
+            ItemQualityPair item = ctx.Item("gear");
+            NodeId farSupplier = session.Editor.CreateSupplierNode(item, new System.Drawing.Point(0, 0));
+            NodeId nearSupplier = session.Editor.CreateSupplierNode(item, new System.Drawing.Point(50, 0));
+            NodeId consumer = session.Editor.CreateConsumerNode(item, new System.Drawing.Point(100, 0));
+            _ = farSupplier;
+            _ = nearSupplier;
+
+            int created = GraphAutoconnect.ConnectDisconnectedInputs(session);
+
+            Assert.AreEqual(1, created);
+            NodeLink link = graph.NodeLinks.Single();
+            Assert.AreEqual(nearSupplier.Value, link.SupplierNode.NodeID);
+            Assert.AreEqual(consumer.Value, link.ConsumerNode.NodeID);
+        }
+    }
+}


### PR DESCRIPTION
There is now a button in the main form that allows you to autoconnect any unconnected inputs to outputs.

The logic is as follows:

* Inputs that are already connected are ignored.
* Inputs are never connected to an output on the same node.
* The nearest node on the diagram is chosen.

Closes #118