### PR TITLE
Implement Text/Shape Annotations

### DIFF
--- a/Foreman/Forms/ImageExportForm.cs
+++ b/Foreman/Forms/ImageExportForm.cs
@@ -1,19 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace Foreman {
     public partial class ImageExportForm : Form {
-        private readonly float[] multipliers = new float[] { 0.05f, 0.1f, 0.2f, 0.5f, 1f, 2f, 3f };
-        private readonly string[] multiplierNames = new string[] { "1/20", "1/10", "1/5", "1/2", "1", "2", "3" };
-        private readonly int initialIndex = 4;
+        private static readonly float[] Multipliers = [0.05f, 0.1f, 0.2f, 0.5f, 1f, 2f, 3f];
+        private static readonly string[] MultiplierNames = ["1/20", "1/10", "1/5", "1/2", "1", "2", "3"];
+        private const int DefaultScaleIndex = 4;
 
         private readonly ProductionGraphViewer graphViewer;
 
@@ -21,89 +17,106 @@ namespace Foreman {
             InitializeComponent();
             this.graphViewer = graphViewer;
 
-            ScaleSelectionBox.Items.AddRange(multiplierNames);
-            ScaleSelectionBox.SelectedIndex = initialIndex;
+            ScaleSelectionBox.Items.AddRange(MultiplierNames);
+            ScaleSelectionBox.SelectedIndex = DefaultScaleIndex;
             UpdateSizeLabel();
         }
 
         private void button1_Click(object? sender, EventArgs e) {
-            using (SaveFileDialog dialog = new SaveFileDialog()) {
-                dialog.AddExtension = true;
-                dialog.Filter = "PNG files (*.png)|*.png";
-                dialog.InitialDirectory = Path.Combine(Application.StartupPath, "Exported Graphs");
-                if (!Directory.Exists(dialog.InitialDirectory))
-                    Directory.CreateDirectory(dialog.InitialDirectory);
-                dialog.FileName = "Foreman Production Flowchart.png";
-                dialog.ValidateNames = true;
-                dialog.OverwritePrompt = true;
-                var result = dialog.ShowDialog();
+            using SaveFileDialog dialog = new() {
+                AddExtension = true,
+                Filter = "PNG files (*.png)|*.png",
+                InitialDirectory = Path.Combine(Application.StartupPath, "Exported Graphs"),
+                FileName = "Foreman Production Flowchart.png",
+                ValidateNames = true,
+                OverwritePrompt = true
+            };
+            if (!Directory.Exists(dialog.InitialDirectory))
+                Directory.CreateDirectory(dialog.InitialDirectory);
 
-                if (result == System.Windows.Forms.DialogResult.OK) {
-                    fileTextBox.Text = dialog.FileName;
-                }
-            }
+            if (dialog.ShowDialog() == DialogResult.OK)
+                fileTextBox.Text = dialog.FileName;
         }
 
         private void ExportButton_Click(object? sender, EventArgs e) {
-            if (string.IsNullOrEmpty(fileTextBox.Text) || string.IsNullOrEmpty(Path.GetDirectoryName(fileTextBox.Text)) || !Directory.Exists(Path.GetDirectoryName(fileTextBox.Text))) {
+            string? directory = Path.GetDirectoryName(fileTextBox.Text);
+            if (string.IsNullOrEmpty(fileTextBox.Text)
+                || string.IsNullOrEmpty(directory)
+                || !Directory.Exists(directory)) {
                 UserMessages.Show("Directory doesn't exist!");
-            } else {
-                graphViewer.ClearSelection();
-
-                float scale = multipliers[ScaleSelectionBox.SelectedIndex];
-
-                Bitmap image = ViewLimitCheckBox.Checked ? new Bitmap((int)(graphViewer.Width * scale / graphViewer.ViewScale), (int)(graphViewer.Height * scale / graphViewer.ViewScale)) : new Bitmap((int)(graphViewer.Graph.Bounds.Width * scale), (int)(graphViewer.Graph.Bounds.Height * scale));
-                using (Graphics graphics = Graphics.FromImage(image)) {
-                    graphics.ResetTransform();
-
-                    if (ViewLimitCheckBox.Checked) {
-                        graphics.TranslateTransform(graphViewer.Width / (graphViewer.ViewScale * 2), graphViewer.Height / (graphViewer.ViewScale * 2));
-                        graphics.TranslateTransform(graphViewer.ViewOffset.X, graphViewer.ViewOffset.Y);
-                        graphics.ScaleTransform(scale, scale);
-                    } else {
-                        graphics.ScaleTransform(scale, scale);
-                        graphics.TranslateTransform(-graphViewer.Graph.Bounds.X, -graphViewer.Graph.Bounds.Y);
-                    }
-
-                    graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.HighQuality;
-
-                    if (!TransparencyCheckBox.Checked)
-                        graphics.Clear(Color.White);
-
-                    graphViewer.Paint(graphics, true);
-
-                    try {
-                        image.Save(fileTextBox.Text, ImageFormat.Png);
-                        Close();
-                    } catch (Exception exception) {
-                        UserMessages.Show("Error saving image. See log for more details.");
-                        ErrorLogging.LogException(exception, "Error saving image");
-                    }
-                }
+                return;
             }
-        }
 
-        private void UpdateSizeLabel() {
-            float scale = multipliers[ScaleSelectionBox.SelectedIndex];
-            int x, y;
+            graphViewer.ClearSelection();
+            float scale = Multipliers[ScaleSelectionBox.SelectedIndex];
 
             if (ViewLimitCheckBox.Checked) {
-                x = (int)(graphViewer.Width * scale / graphViewer.ViewScale);
-                y = (int)(graphViewer.Height * scale / graphViewer.ViewScale);
-            } else {
-                x = (int)(graphViewer.Graph.Bounds.Width * scale);
-                y = (int)(graphViewer.Graph.Bounds.Height * scale);
+                ExportBitmap(ViewLimitedBounds(), scale, ConfigureViewLimitedTransform);
+                return;
             }
 
-            ImageSizeLabel.Text = string.Format("Image Size: {0} x {1}", x.ToString("N0"), y.ToString("N0"));
+            Rectangle exportBounds = graphViewer.GetExportBounds();
+            if (!GraphExportBounds.IsExportable(exportBounds)) {
+                UserMessages.Show("There is nothing to export. Add nodes or annotations to the graph first.");
+                return;
+            }
+
+            ExportBitmap(exportBounds, scale, (graphics, bounds) => {
+                graphics.ScaleTransform(scale, scale);
+                graphics.TranslateTransform(-bounds.X, -bounds.Y);
+            });
         }
 
-        private void ViewLimitCheckBox_CheckedChanged(object? sender, EventArgs e) {
-            UpdateSizeLabel();
+        private void ExportBitmap(Rectangle bounds, float scale, Action<Graphics, Rectangle> configureTransform) {
+            using Bitmap image = new(GraphExportBounds.ScaledWidth(bounds, scale), GraphExportBounds.ScaledHeight(bounds, scale));
+            using Graphics graphics = Graphics.FromImage(image);
+            graphics.ResetTransform();
+            configureTransform(graphics, bounds);
+            graphics.SmoothingMode = SmoothingMode.HighQuality;
+
+            if (!TransparencyCheckBox.Checked)
+                graphics.Clear(graphViewer.BackColor);
+
+            graphViewer.Paint(graphics, FullGraph: true);
+
+            try {
+                image.Save(fileTextBox.Text, ImageFormat.Png);
+                Close();
+            } catch (Exception exception) {
+                UserMessages.Show("Error saving image. See log for more details.");
+                ErrorLogging.LogException(exception, "Error saving image");
+            }
         }
 
-        private void ScaleSelectionBox_SelectedIndexChanged(object? sender, EventArgs e) {
-            UpdateSizeLabel();
+        private void ConfigureViewLimitedTransform(Graphics graphics, Rectangle _) {
+            graphics.TranslateTransform(
+                graphViewer.Width / (graphViewer.ViewScale * 2),
+                graphViewer.Height / (graphViewer.ViewScale * 2));
+            graphics.TranslateTransform(graphViewer.ViewOffset.X, graphViewer.ViewOffset.Y);
+            graphics.ScaleTransform(Multipliers[ScaleSelectionBox.SelectedIndex], Multipliers[ScaleSelectionBox.SelectedIndex]);
         }
+
+        private Rectangle ViewLimitedBounds() =>
+            new(0, 0, (int)(graphViewer.Width / graphViewer.ViewScale), (int)(graphViewer.Height / graphViewer.ViewScale));
+
+        private void UpdateSizeLabel() {
+            float scale = Multipliers[ScaleSelectionBox.SelectedIndex];
+            Rectangle bounds = ViewLimitCheckBox.Checked
+                ? ViewLimitedBounds()
+                : graphViewer.GetExportBounds();
+
+            if (!GraphExportBounds.IsExportable(bounds)) {
+                ImageSizeLabel.Text = "Image Size: — (nothing to export)";
+                return;
+            }
+
+            int x = GraphExportBounds.ScaledWidth(bounds, scale);
+            int y = GraphExportBounds.ScaledHeight(bounds, scale);
+            ImageSizeLabel.Text = $"Image Size: {x:N0} x {y:N0}";
+        }
+
+        private void ViewLimitCheckBox_CheckedChanged(object? sender, EventArgs e) => UpdateSizeLabel();
+
+        private void ScaleSelectionBox_SelectedIndexChanged(object? sender, EventArgs e) => UpdateSizeLabel();
     }
 }

--- a/Foreman/Forms/ShapePropertiesForm.Designer.cs
+++ b/Foreman/Forms/ShapePropertiesForm.Designer.cs
@@ -1,0 +1,171 @@
+namespace Foreman
+{
+    partial class ShapePropertiesForm
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+                components.Dispose();
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.ShapeTypeLabel = new System.Windows.Forms.Label();
+            this.ShapeTypeCombo = new System.Windows.Forms.ComboBox();
+            this.FillColorLabel = new System.Windows.Forms.Label();
+            this.FillColorButton = new System.Windows.Forms.Button();
+            this.FillAlphaLabel = new System.Windows.Forms.Label();
+            this.FillAlphaTrack = new System.Windows.Forms.TrackBar();
+            this.NoFillCheckBox = new System.Windows.Forms.CheckBox();
+            this.BorderColorLabel = new System.Windows.Forms.Label();
+            this.BorderColorButton = new System.Windows.Forms.Button();
+            this.BorderWidthLabel = new System.Windows.Forms.Label();
+            this.BorderWidthInput = new System.Windows.Forms.NumericUpDown();
+            this.OKButton = new System.Windows.Forms.Button();
+            this.CancelBtn = new System.Windows.Forms.Button();
+            ((System.ComponentModel.ISupportInitialize)(this.FillAlphaTrack)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.BorderWidthInput)).BeginInit();
+            this.SuspendLayout();
+
+            // ShapeTypeLabel
+            this.ShapeTypeLabel.AutoSize = true;
+            this.ShapeTypeLabel.Location = new System.Drawing.Point(12, 15);
+            this.ShapeTypeLabel.Text = "Shape Type:";
+
+            // ShapeTypeCombo
+            this.ShapeTypeCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.ShapeTypeCombo.Items.AddRange(new object[] { "Rectangle", "Ellipse" });
+            this.ShapeTypeCombo.Location = new System.Drawing.Point(120, 12);
+            this.ShapeTypeCombo.Size = new System.Drawing.Size(130, 21);
+            this.ShapeTypeCombo.TabIndex = 0;
+            this.ShapeTypeCombo.SelectedIndexChanged += new System.EventHandler(this.ShapeTypeCombo_SelectedIndexChanged);
+
+            // FillColorLabel
+            this.FillColorLabel.AutoSize = true;
+            this.FillColorLabel.Location = new System.Drawing.Point(12, 50);
+            this.FillColorLabel.Text = "Fill Colour:";
+
+            // FillColorButton
+            this.FillColorButton.Location = new System.Drawing.Point(120, 47);
+            this.FillColorButton.Size = new System.Drawing.Size(130, 26);
+            this.FillColorButton.TabIndex = 1;
+            this.FillColorButton.Text = "Choose…";
+            this.FillColorButton.UseVisualStyleBackColor = false;
+            this.FillColorButton.Click += new System.EventHandler(this.FillColorButton_Click);
+
+            // NoFillCheckBox
+            this.NoFillCheckBox.AutoSize = true;
+            this.NoFillCheckBox.Location = new System.Drawing.Point(12, 82);
+            this.NoFillCheckBox.TabIndex = 2;
+            this.NoFillCheckBox.Text = "No fill";
+            this.NoFillCheckBox.UseVisualStyleBackColor = true;
+            this.NoFillCheckBox.CheckedChanged += new System.EventHandler(this.NoFillCheckBox_CheckedChanged);
+
+            // FillAlphaLabel
+            this.FillAlphaLabel.AutoSize = true;
+            this.FillAlphaLabel.Location = new System.Drawing.Point(12, 108);
+            this.FillAlphaLabel.Text = "Opacity: 255";
+
+            // FillAlphaTrack
+            this.FillAlphaTrack.Location = new System.Drawing.Point(120, 104);
+            this.FillAlphaTrack.Maximum = 255;
+            this.FillAlphaTrack.Minimum = 0;
+            this.FillAlphaTrack.Size = new System.Drawing.Size(130, 30);
+            this.FillAlphaTrack.TabIndex = 3;
+            this.FillAlphaTrack.TickFrequency = 32;
+            this.FillAlphaTrack.Value = 255;
+            this.FillAlphaTrack.Scroll += new System.EventHandler(this.FillAlphaTrack_Scroll);
+
+            // BorderColorLabel
+            this.BorderColorLabel.AutoSize = true;
+            this.BorderColorLabel.Location = new System.Drawing.Point(12, 150);
+            this.BorderColorLabel.Text = "Border Colour:";
+
+            // BorderColorButton
+            this.BorderColorButton.Location = new System.Drawing.Point(120, 147);
+            this.BorderColorButton.Size = new System.Drawing.Size(130, 26);
+            this.BorderColorButton.TabIndex = 4;
+            this.BorderColorButton.Text = "Choose…";
+            this.BorderColorButton.UseVisualStyleBackColor = false;
+            this.BorderColorButton.Click += new System.EventHandler(this.BorderColorButton_Click);
+
+            // BorderWidthLabel
+            this.BorderWidthLabel.AutoSize = true;
+            this.BorderWidthLabel.Location = new System.Drawing.Point(12, 185);
+            this.BorderWidthLabel.Text = "Border Width:";
+
+            // BorderWidthInput
+            this.BorderWidthInput.Location = new System.Drawing.Point(120, 183);
+            this.BorderWidthInput.Maximum = new decimal(new int[] { 20, 0, 0, 0 });
+            this.BorderWidthInput.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
+            this.BorderWidthInput.Size = new System.Drawing.Size(60, 20);
+            this.BorderWidthInput.TabIndex = 5;
+            this.BorderWidthInput.Value = new decimal(new int[] { 2, 0, 0, 0 });
+            this.BorderWidthInput.ValueChanged += new System.EventHandler(this.BorderWidthInput_ValueChanged);
+
+            // OKButton
+            this.OKButton.Location = new System.Drawing.Point(90, 220);
+            this.OKButton.Size = new System.Drawing.Size(75, 26);
+            this.OKButton.TabIndex = 6;
+            this.OKButton.Text = "OK";
+            this.OKButton.UseVisualStyleBackColor = true;
+            this.OKButton.Click += new System.EventHandler(this.OKButton_Click);
+
+            // CancelBtn
+            this.CancelBtn.Location = new System.Drawing.Point(175, 220);
+            this.CancelBtn.Size = new System.Drawing.Size(75, 26);
+            this.CancelBtn.TabIndex = 7;
+            this.CancelBtn.Text = "Cancel";
+            this.CancelBtn.UseVisualStyleBackColor = true;
+            this.CancelBtn.Click += new System.EventHandler(this.CancelButton_Click);
+
+            // ShapePropertiesForm
+            this.AcceptButton = this.OKButton;
+            this.CancelButton = this.CancelBtn;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(264, 258);
+            this.Controls.Add(this.ShapeTypeLabel);
+            this.Controls.Add(this.ShapeTypeCombo);
+            this.Controls.Add(this.FillColorLabel);
+            this.Controls.Add(this.FillColorButton);
+            this.Controls.Add(this.NoFillCheckBox);
+            this.Controls.Add(this.FillAlphaLabel);
+            this.Controls.Add(this.FillAlphaTrack);
+            this.Controls.Add(this.BorderColorLabel);
+            this.Controls.Add(this.BorderColorButton);
+            this.Controls.Add(this.BorderWidthLabel);
+            this.Controls.Add(this.BorderWidthInput);
+            this.Controls.Add(this.OKButton);
+            this.Controls.Add(this.CancelBtn);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "ShapePropertiesForm";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Shape Properties";
+            ((System.ComponentModel.ISupportInitialize)(this.FillAlphaTrack)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.BorderWidthInput)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        private System.Windows.Forms.Label ShapeTypeLabel;
+        private System.Windows.Forms.ComboBox ShapeTypeCombo;
+        private System.Windows.Forms.Label FillColorLabel;
+        private System.Windows.Forms.Button FillColorButton;
+        private System.Windows.Forms.Label FillAlphaLabel;
+        private System.Windows.Forms.TrackBar FillAlphaTrack;
+        private System.Windows.Forms.CheckBox NoFillCheckBox;
+        private System.Windows.Forms.Label BorderColorLabel;
+        private System.Windows.Forms.Button BorderColorButton;
+        private System.Windows.Forms.Label BorderWidthLabel;
+        private System.Windows.Forms.NumericUpDown BorderWidthInput;
+        private System.Windows.Forms.Button OKButton;
+        private System.Windows.Forms.Button CancelBtn;
+    }
+}

--- a/Foreman/Forms/ShapePropertiesForm.cs
+++ b/Foreman/Forms/ShapePropertiesForm.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Foreman {
+    public partial class ShapePropertiesForm : Form {
+        private readonly ShapeAnnotationElement _element;
+        private readonly ProductionGraphViewer _graphViewer;
+
+        private readonly ShapeAnnotationElement.ShapeType _originalShapeType;
+        private readonly Color _originalFillColor;
+        private readonly Color _originalBorderColor;
+        private readonly int _originalBorderWidth;
+
+        public ShapePropertiesForm(ShapeAnnotationElement element) {
+            InitializeComponent();
+            _element = element;
+            _graphViewer = element.GraphViewer;
+
+            _originalShapeType = element.CurrentShapeType;
+            _originalFillColor = element.FillColor;
+            _originalBorderColor = element.BorderColor;
+            _originalBorderWidth = element.BorderWidth;
+
+            ShapeTypeCombo.SelectedIndex = element.CurrentShapeType == ShapeAnnotationElement.ShapeType.Ellipse ? 1 : 0;
+            BorderWidthInput.Value = Math.Max(BorderWidthInput.Minimum, Math.Min(BorderWidthInput.Maximum, element.BorderWidth));
+
+            NoFillCheckBox.CheckedChanged -= NoFillCheckBox_CheckedChanged;
+            NoFillCheckBox.Checked = element.FillColor.A == 0;
+            NoFillCheckBox.CheckedChanged += NoFillCheckBox_CheckedChanged;
+
+            bool noFill = NoFillCheckBox.Checked;
+            FillColorButton.Enabled = !noFill;
+            FillAlphaTrack.Enabled = !noFill;
+            FillColorButton.BackColor = Color.FromArgb(255, element.FillColor.R, element.FillColor.G, element.FillColor.B);
+            FillColorButton.ForeColor = element.FillColor.R + element.FillColor.G + element.FillColor.B > 382
+                ? Color.Black
+                : Color.White;
+            FillAlphaTrack.Value = element.FillColor.A;
+            FillAlphaLabel.Text = string.Format("Opacity: {0}", element.FillColor.A);
+            UpdateBorderButton();
+        }
+
+        private void ShapeTypeCombo_SelectedIndexChanged(object? sender, EventArgs e) {
+            _element.CurrentShapeType = ShapeTypeCombo.SelectedIndex == 1
+                ? ShapeAnnotationElement.ShapeType.Ellipse
+                : ShapeAnnotationElement.ShapeType.Rectangle;
+            _element.RebuildGdiObjects();
+            _graphViewer.Invalidate();
+        }
+
+        private void FillColorButton_Click(object? sender, EventArgs e) {
+            using var dlg = new ColorDialog {
+                Color = Color.FromArgb(255, _element.FillColor.R, _element.FillColor.G, _element.FillColor.B),
+                AnyColor = true,
+                FullOpen = true
+            };
+            if (dlg.ShowDialog(this) != DialogResult.OK)
+                return;
+            _element.FillColor = Color.FromArgb(_element.FillColor.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
+            _element.RebuildGdiObjects();
+            _graphViewer.Invalidate();
+            UpdateFillButton();
+        }
+
+        private void UpdateFillButton() {
+            FillColorButton.BackColor = Color.FromArgb(255, _element.FillColor.R, _element.FillColor.G, _element.FillColor.B);
+            FillColorButton.ForeColor = _element.FillColor.R + _element.FillColor.G + _element.FillColor.B > 382
+                ? Color.Black
+                : Color.White;
+            FillAlphaLabel.Text = string.Format("Opacity: {0}", _element.FillColor.A);
+            FillAlphaTrack.Value = _element.FillColor.A;
+        }
+
+        private void FillAlphaTrack_Scroll(object? sender, EventArgs e) {
+            _element.FillColor = Color.FromArgb(FillAlphaTrack.Value, _element.FillColor.R, _element.FillColor.G, _element.FillColor.B);
+            FillAlphaLabel.Text = string.Format("Opacity: {0}", _element.FillColor.A);
+            _element.RebuildGdiObjects();
+            _graphViewer.Invalidate();
+        }
+
+        private void NoFillCheckBox_CheckedChanged(object? sender, EventArgs e) {
+            FillColorButton.Enabled = !NoFillCheckBox.Checked;
+            FillAlphaTrack.Enabled = !NoFillCheckBox.Checked;
+            if (NoFillCheckBox.Checked) {
+                _element.FillColor = Color.FromArgb(0, _element.FillColor.R, _element.FillColor.G, _element.FillColor.B);
+                FillAlphaTrack.Value = 0;
+                FillAlphaLabel.Text = "Opacity: 0";
+            } else {
+                _element.FillColor = Color.FromArgb(255, _element.FillColor.R, _element.FillColor.G, _element.FillColor.B);
+                FillAlphaTrack.Value = 255;
+                FillAlphaLabel.Text = "Opacity: 255";
+            }
+            _element.RebuildGdiObjects();
+            _graphViewer.Invalidate();
+        }
+
+        private void BorderColorButton_Click(object? sender, EventArgs e) {
+            using var dlg = new ColorDialog { Color = _element.BorderColor, AnyColor = true, FullOpen = true };
+            if (dlg.ShowDialog(this) != DialogResult.OK)
+                return;
+            _element.BorderColor = dlg.Color;
+            _element.RebuildGdiObjects();
+            _graphViewer.Invalidate();
+            UpdateBorderButton();
+        }
+
+        private void UpdateBorderButton() {
+            BorderColorButton.BackColor = Color.FromArgb(255, _element.BorderColor.R, _element.BorderColor.G, _element.BorderColor.B);
+            BorderColorButton.ForeColor = _element.BorderColor.R + _element.BorderColor.G + _element.BorderColor.B > 382
+                ? Color.Black
+                : Color.White;
+        }
+
+        private void BorderWidthInput_ValueChanged(object? sender, EventArgs e) {
+            _element.BorderWidth = (int)BorderWidthInput.Value;
+            _element.RebuildGdiObjects();
+            _graphViewer.Invalidate();
+        }
+
+        private void OKButton_Click(object? sender, EventArgs e) {
+            ShapeAnnotationElement.SaveDefaults(_element);
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        private void CancelButton_Click(object? sender, EventArgs e) {
+            _element.CurrentShapeType = _originalShapeType;
+            _element.FillColor = _originalFillColor;
+            _element.BorderColor = _originalBorderColor;
+            _element.BorderWidth = _originalBorderWidth;
+            _element.RebuildGdiObjects();
+            _graphViewer.Invalidate();
+            DialogResult = DialogResult.Cancel;
+            Close();
+        }
+    }
+}

--- a/Foreman/Forms/TextPropertiesForm.Designer.cs
+++ b/Foreman/Forms/TextPropertiesForm.Designer.cs
@@ -1,0 +1,196 @@
+namespace Foreman {
+    partial class TextPropertiesForm
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+                components.Dispose();
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.TextLabel = new System.Windows.Forms.Label();
+            this.TextInput = new System.Windows.Forms.TextBox();
+            this.FontLabel = new System.Windows.Forms.Label();
+            this.FontButton = new System.Windows.Forms.Button();
+            this.FontPreviewLabel = new System.Windows.Forms.Label();
+            this.AlignLabel = new System.Windows.Forms.Label();
+            this.AlignLeftRadio = new System.Windows.Forms.RadioButton();
+            this.AlignCenterRadio = new System.Windows.Forms.RadioButton();
+            this.AlignRightRadio = new System.Windows.Forms.RadioButton();
+            this.TextColorLabel = new System.Windows.Forms.Label();
+            this.TextColorButton = new System.Windows.Forms.Button();
+            this.BackColorLabel = new System.Windows.Forms.Label();
+            this.BackColorButton = new System.Windows.Forms.Button();
+            this.TransparentCheckBox = new System.Windows.Forms.CheckBox();
+            this.OKButton = new System.Windows.Forms.Button();
+            this.CancelBtn = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+
+            // TextLabel
+            this.TextLabel.AutoSize = true;
+            this.TextLabel.Location = new System.Drawing.Point(12, 15);
+            this.TextLabel.Text = "Label Text:";
+
+            // TextInput
+            this.TextInput.Location = new System.Drawing.Point(120, 12);
+            this.TextInput.Size = new System.Drawing.Size(200, 20);
+            this.TextInput.TabIndex = 0;
+            this.TextInput.TextChanged += new System.EventHandler(this.TextInput_TextChanged);
+
+            // FontLabel
+            this.FontLabel.AutoSize = true;
+            this.FontLabel.Location = new System.Drawing.Point(12, 48);
+            this.FontLabel.Text = "Font:";
+
+            // FontButton
+            this.FontButton.Location = new System.Drawing.Point(120, 44);
+            this.FontButton.Size = new System.Drawing.Size(100, 26);
+            this.FontButton.TabIndex = 1;
+            this.FontButton.Text = "Choose Font…";
+            this.FontButton.UseVisualStyleBackColor = true;
+            this.FontButton.Click += new System.EventHandler(this.FontButton_Click);
+
+            // FontPreviewLabel
+            this.FontPreviewLabel.AutoSize = true;
+            this.FontPreviewLabel.Location = new System.Drawing.Point(12, 78);
+            this.FontPreviewLabel.Size = new System.Drawing.Size(310, 13);
+            this.FontPreviewLabel.Name = "FontPreviewLabel";
+            this.FontPreviewLabel.Text = "";
+
+            // AlignLabel
+            this.AlignLabel.AutoSize = true;
+            this.AlignLabel.Location = new System.Drawing.Point(12, 104);
+            this.AlignLabel.Text = "Alignment:";
+
+            // AlignLeftRadio
+            this.AlignLeftRadio.AutoSize = true;
+            this.AlignLeftRadio.Location = new System.Drawing.Point(120, 101);
+            this.AlignLeftRadio.Size = new System.Drawing.Size(46, 17);
+            this.AlignLeftRadio.TabIndex = 2;
+            this.AlignLeftRadio.Text = "Left";
+            this.AlignLeftRadio.UseVisualStyleBackColor = true;
+            this.AlignLeftRadio.CheckedChanged += new System.EventHandler(this.AlignRadio_CheckedChanged);
+
+            // AlignCenterRadio
+            this.AlignCenterRadio.AutoSize = true;
+            this.AlignCenterRadio.Location = new System.Drawing.Point(178, 101);
+            this.AlignCenterRadio.Size = new System.Drawing.Size(56, 17);
+            this.AlignCenterRadio.TabIndex = 3;
+            this.AlignCenterRadio.Text = "Center";
+            this.AlignCenterRadio.UseVisualStyleBackColor = true;
+            this.AlignCenterRadio.CheckedChanged += new System.EventHandler(this.AlignRadio_CheckedChanged);
+
+            // AlignRightRadio
+            this.AlignRightRadio.AutoSize = true;
+            this.AlignRightRadio.Location = new System.Drawing.Point(246, 101);
+            this.AlignRightRadio.Size = new System.Drawing.Size(51, 17);
+            this.AlignRightRadio.TabIndex = 4;
+            this.AlignRightRadio.Text = "Right";
+            this.AlignRightRadio.UseVisualStyleBackColor = true;
+            this.AlignRightRadio.CheckedChanged += new System.EventHandler(this.AlignRadio_CheckedChanged);
+
+            // TextColorLabel
+            this.TextColorLabel.AutoSize = true;
+            this.TextColorLabel.Location = new System.Drawing.Point(12, 132);
+            this.TextColorLabel.Text = "Text Colour:";
+
+            // TextColorButton
+            this.TextColorButton.Location = new System.Drawing.Point(120, 129);
+            this.TextColorButton.Size = new System.Drawing.Size(130, 26);
+            this.TextColorButton.TabIndex = 5;
+            this.TextColorButton.Text = "Choose…";
+            this.TextColorButton.UseVisualStyleBackColor = false;
+            this.TextColorButton.Click += new System.EventHandler(this.TextColorButton_Click);
+
+            // BackColorLabel
+            this.BackColorLabel.AutoSize = true;
+            this.BackColorLabel.Location = new System.Drawing.Point(12, 168);
+            this.BackColorLabel.Text = "Background:";
+
+            // BackColorButton
+            this.BackColorButton.Location = new System.Drawing.Point(120, 165);
+            this.BackColorButton.Size = new System.Drawing.Size(130, 26);
+            this.BackColorButton.TabIndex = 6;
+            this.BackColorButton.Text = "Choose…";
+            this.BackColorButton.UseVisualStyleBackColor = false;
+            this.BackColorButton.Click += new System.EventHandler(this.BackColorButton_Click);
+
+            // TransparentCheckBox
+            this.TransparentCheckBox.AutoSize = true;
+            this.TransparentCheckBox.Location = new System.Drawing.Point(120, 198);
+            this.TransparentCheckBox.TabIndex = 7;
+            this.TransparentCheckBox.Text = "Transparent background";
+            this.TransparentCheckBox.UseVisualStyleBackColor = true;
+            this.TransparentCheckBox.CheckedChanged += new System.EventHandler(this.TransparentCheckBox_CheckedChanged);
+
+            // OKButton
+            this.OKButton.Location = new System.Drawing.Point(130, 228);
+            this.OKButton.Size = new System.Drawing.Size(75, 26);
+            this.OKButton.TabIndex = 8;
+            this.OKButton.Text = "OK";
+            this.OKButton.UseVisualStyleBackColor = true;
+            this.OKButton.Click += new System.EventHandler(this.OKButton_Click);
+
+            // CancelBtn
+            this.CancelBtn.Location = new System.Drawing.Point(215, 228);
+            this.CancelBtn.Size = new System.Drawing.Size(75, 26);
+            this.CancelBtn.TabIndex = 9;
+            this.CancelBtn.Text = "Cancel";
+            this.CancelBtn.UseVisualStyleBackColor = true;
+            this.CancelBtn.Click += new System.EventHandler(this.CancelButton_Click);
+
+            // TextPropertiesForm
+            this.AcceptButton = this.OKButton;
+            this.CancelButton = this.CancelBtn;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(340, 266);
+            this.Controls.Add(this.TextLabel);
+            this.Controls.Add(this.TextInput);
+            this.Controls.Add(this.FontLabel);
+            this.Controls.Add(this.FontButton);
+            this.Controls.Add(this.FontPreviewLabel);
+            this.Controls.Add(this.AlignLabel);
+            this.Controls.Add(this.AlignLeftRadio);
+            this.Controls.Add(this.AlignCenterRadio);
+            this.Controls.Add(this.AlignRightRadio);
+            this.Controls.Add(this.TextColorLabel);
+            this.Controls.Add(this.TextColorButton);
+            this.Controls.Add(this.BackColorLabel);
+            this.Controls.Add(this.BackColorButton);
+            this.Controls.Add(this.TransparentCheckBox);
+            this.Controls.Add(this.OKButton);
+            this.Controls.Add(this.CancelBtn);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "TextPropertiesForm";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Text Properties";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        private System.Windows.Forms.Label TextLabel;
+        private System.Windows.Forms.TextBox TextInput;
+        private System.Windows.Forms.Label FontLabel;
+        private System.Windows.Forms.Button FontButton;
+        private System.Windows.Forms.Label FontPreviewLabel;
+        private System.Windows.Forms.Label AlignLabel;
+        private System.Windows.Forms.RadioButton AlignLeftRadio;
+        private System.Windows.Forms.RadioButton AlignCenterRadio;
+        private System.Windows.Forms.RadioButton AlignRightRadio;
+        private System.Windows.Forms.Label TextColorLabel;
+        private System.Windows.Forms.Button TextColorButton;
+        private System.Windows.Forms.Label BackColorLabel;
+        private System.Windows.Forms.Button BackColorButton;
+        private System.Windows.Forms.CheckBox TransparentCheckBox;
+        private System.Windows.Forms.Button OKButton;
+        private System.Windows.Forms.Button CancelBtn;
+    }
+}

--- a/Foreman/Forms/TextPropertiesForm.cs
+++ b/Foreman/Forms/TextPropertiesForm.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Foreman {
+    public partial class TextPropertiesForm : Form {
+        private readonly TextAnnotationElement _element;
+        private readonly ProductionGraphViewer _graphViewer;
+
+        private readonly string _originalText;
+        private readonly Font _originalFont;
+        private readonly Color _originalTextColor;
+        private readonly Color _originalBackColor;
+        private readonly StringAlignment _originalTextAlign;
+
+        private Font? _workingFont;
+
+        public TextPropertiesForm(TextAnnotationElement element) {
+            InitializeComponent();
+            _element = element;
+            _graphViewer = element.GraphViewer;
+
+            _originalText = element.Text;
+            _originalFont = new Font(element.TextFont, element.TextFont.Style);
+            _originalTextColor = element.TextColor;
+            _originalBackColor = element.BackColor;
+            _originalTextAlign = element.TextAlign;
+            _workingFont = new Font(element.TextFont, element.TextFont.Style);
+
+            TextInput.TextChanged -= TextInput_TextChanged;
+            TextInput.Text = element.Text;
+            TextInput.TextChanged += TextInput_TextChanged;
+
+            UpdateFontLabel();
+            UpdateAlignRadios();
+            UpdateTextColorButton();
+            UpdateBackColorButton();
+
+            TransparentCheckBox.CheckedChanged -= TransparentCheckBox_CheckedChanged;
+            TransparentCheckBox.Checked = element.BackColor.A == 0;
+            TransparentCheckBox.CheckedChanged += TransparentCheckBox_CheckedChanged;
+            BackColorButton.Enabled = !TransparentCheckBox.Checked;
+            Shown += (_, _) => { TextInput.Focus(); TextInput.SelectAll(); };
+        }
+
+        private void TextInput_TextChanged(object? sender, EventArgs e) {
+            _element.Text = TextInput.Text;
+            _element.FitBoxToTextAtCenter();
+            _graphViewer.Invalidate();
+        }
+
+        private void FontButton_Click(object? sender, EventArgs e) {
+            using var dlg = new FontDialog {
+                Font = _workingFont ?? _originalFont,
+                ShowEffects = true,
+                ShowColor = false,
+                FontMustExist = true
+            };
+            if (dlg.ShowDialog(this) != DialogResult.OK)
+                return;
+
+            _workingFont?.Dispose();
+            var chosenFont = dlg.Font ?? _originalFont;
+            _workingFont = chosenFont;
+            _element.TextFont?.Dispose();
+            _element.TextFont = new Font(chosenFont, chosenFont.Style);
+            _element.RebuildGdiObjects();
+            _element.FitBoxToTextAtCenter();
+            _graphViewer.Invalidate();
+            UpdateFontLabel();
+        }
+
+        private void UpdateAlignRadios() {
+            AlignLeftRadio.CheckedChanged -= AlignRadio_CheckedChanged;
+            AlignCenterRadio.CheckedChanged -= AlignRadio_CheckedChanged;
+            AlignRightRadio.CheckedChanged -= AlignRadio_CheckedChanged;
+
+            AlignLeftRadio.Checked = _element.TextAlign == StringAlignment.Near;
+            AlignCenterRadio.Checked = _element.TextAlign == StringAlignment.Center;
+            AlignRightRadio.Checked = _element.TextAlign == StringAlignment.Far;
+
+            AlignLeftRadio.CheckedChanged += AlignRadio_CheckedChanged;
+            AlignCenterRadio.CheckedChanged += AlignRadio_CheckedChanged;
+            AlignRightRadio.CheckedChanged += AlignRadio_CheckedChanged;
+        }
+
+        private void AlignRadio_CheckedChanged(object? sender, EventArgs e) {
+            if (AlignLeftRadio.Checked)
+                _element.TextAlign = StringAlignment.Near;
+            else if (AlignCenterRadio.Checked)
+                _element.TextAlign = StringAlignment.Center;
+            else if (AlignRightRadio.Checked)
+                _element.TextAlign = StringAlignment.Far;
+            _element.RebuildGdiObjects();
+            _graphViewer.Invalidate();
+        }
+
+        private void UpdateFontLabel() {
+            if (_workingFont is null)
+                return;
+            FontPreviewLabel.Text = string.Format("{0}, {1}pt{2}{3}",
+                _workingFont.FontFamily.Name,
+                (int)_workingFont.SizeInPoints,
+                _workingFont.Bold ? " Bold" : "",
+                _workingFont.Italic ? " Italic" : "");
+        }
+
+        private void TextColorButton_Click(object? sender, EventArgs e) {
+            using var dlg = new ColorDialog { Color = _element.TextColor, AnyColor = true, FullOpen = true };
+            if (dlg.ShowDialog(this) != DialogResult.OK)
+                return;
+            _element.TextColor = dlg.Color;
+            _element.RebuildGdiObjects();
+            _graphViewer.Invalidate();
+            UpdateTextColorButton();
+        }
+
+        private void UpdateTextColorButton() {
+            TextColorButton.BackColor = _element.TextColor;
+            TextColorButton.ForeColor = _element.TextColor.R + _element.TextColor.G + _element.TextColor.B > 382
+                ? Color.Black
+                : Color.White;
+        }
+
+        private void BackColorButton_Click(object? sender, EventArgs e) {
+            using var dlg = new ColorDialog {
+                Color = Color.FromArgb(255, _element.BackColor.R, _element.BackColor.G, _element.BackColor.B),
+                AnyColor = true,
+                FullOpen = true
+            };
+            if (dlg.ShowDialog(this) != DialogResult.OK)
+                return;
+            _element.BackColor = dlg.Color;
+            _element.RebuildGdiObjects();
+            _graphViewer.Invalidate();
+            UpdateBackColorButton();
+        }
+
+        private void UpdateBackColorButton() {
+            Color display = Color.FromArgb(255, _element.BackColor.R, _element.BackColor.G, _element.BackColor.B);
+            BackColorButton.BackColor = display;
+            BackColorButton.ForeColor = display.R + display.G + display.B > 382 ? Color.Black : Color.White;
+        }
+
+        private void TransparentCheckBox_CheckedChanged(object? sender, EventArgs e) {
+            BackColorButton.Enabled = !TransparentCheckBox.Checked;
+            _element.BackColor = TransparentCheckBox.Checked
+                ? Color.Transparent
+                : Color.FromArgb(255, _element.BackColor.R, _element.BackColor.G, _element.BackColor.B);
+            _element.RebuildGdiObjects();
+            _graphViewer.Invalidate();
+        }
+
+        private void OKButton_Click(object? sender, EventArgs e) {
+            TextAnnotationElement.SaveDefaults(_element);
+            _workingFont?.Dispose();
+            _workingFont = null;
+            _originalFont.Dispose();
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        private void CancelButton_Click(object? sender, EventArgs e) {
+            _element.Text = _originalText;
+            _element.TextFont?.Dispose();
+            _element.TextFont = _originalFont;
+            _element.TextColor = _originalTextColor;
+            _element.BackColor = _originalBackColor;
+            _element.TextAlign = _originalTextAlign;
+            _element.RebuildGdiObjects();
+            _graphViewer.Invalidate();
+            _workingFont?.Dispose();
+            _workingFont = null;
+            DialogResult = DialogResult.Cancel;
+            Close();
+        }
+
+        protected override void OnFormClosed(FormClosedEventArgs e) {
+            base.OnFormClosed(e);
+            _workingFont?.Dispose();
+        }
+    }
+}

--- a/Foreman/ProductionGraphView/Annotations/AnnotationClipboardCodec.cs
+++ b/Foreman/ProductionGraphView/Annotations/AnnotationClipboardCodec.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Foreman {
+    /// <summary>Reads and writes annotation payloads embedded in graph clipboard JSON.</summary>
+    public static class AnnotationClipboardCodec {
+        public static IReadOnlyList<AnnotationSaveData>? ReadAnnotations(string json) {
+            try {
+                JsonNode? root = JsonNode.Parse(json);
+                return AnnotationJson.DeserializeListFromRoot(root);
+            } catch (JsonException) {
+                return null;
+            }
+        }
+
+        public static string MergeAnnotationsIntoFragment(
+            string productionGraphFragmentJson,
+            IEnumerable<AnnotationSaveData> annotations) {
+            JsonNode? parsed;
+            try {
+                parsed = JsonNode.Parse(productionGraphFragmentJson);
+            } catch (JsonException) {
+                return productionGraphFragmentJson;
+            }
+
+            if (parsed is not JsonObject root)
+                return productionGraphFragmentJson;
+
+            root["Annotations"] = AnnotationJson.SerializeToArray(annotations);
+            return root.ToJsonString(GraphSaveJsonOptions.Get(writeIndented: false));
+        }
+    }
+}

--- a/Foreman/ProductionGraphView/Annotations/AnnotationSelectionModifiers.cs
+++ b/Foreman/ProductionGraphView/Annotations/AnnotationSelectionModifiers.cs
@@ -1,0 +1,14 @@
+﻿using System.Windows.Forms;
+
+namespace Foreman {
+    internal static class AnnotationSelectionModifiers {
+        public static bool IsRemoveFromSelection =>
+            (Control.ModifierKeys & Keys.Alt) != 0;
+
+        public static bool IsAddToSelection =>
+            (Control.ModifierKeys & Keys.Control) != 0;
+
+        public static bool IsReplaceSelection =>
+            !IsRemoveFromSelection && !IsAddToSelection;
+    }
+}

--- a/Foreman/ProductionGraphView/Annotations/GraphExportBounds.cs
+++ b/Foreman/ProductionGraphView/Annotations/GraphExportBounds.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+
+namespace Foreman {
+    /// <summary>Bounds and pixel sizing for full-graph PNG export (nodes, links, and annotations).</summary>
+    public static class GraphExportBounds {
+        /// <summary>Padding around annotation-only exports (graph bounds already include node borders).</summary>
+        public const int AnnotationOnlyPadding = 50;
+
+        public static bool IsExportable(Rectangle bounds) =>
+            bounds.Width > 0 && bounds.Height > 0;
+
+        public static Rectangle GetGraphBounds(AnnotationElement annotation) =>
+            new(
+                annotation.X - annotation.Width / 2,
+                annotation.Y - annotation.Height / 2,
+                annotation.Width,
+                annotation.Height);
+
+        public static Rectangle Compute(Rectangle graphBounds, IEnumerable<Rectangle> annotationBounds) {
+            List<Rectangle> annotations = annotationBounds
+                .Where(r => r.Width > 0 && r.Height > 0)
+                .ToList();
+
+            bool hasGraph = graphBounds.Width > 0 && graphBounds.Height > 0;
+            bool hasAnnotations = annotations.Count > 0;
+
+            if (!hasGraph && !hasAnnotations)
+                return Rectangle.Empty;
+
+            if (hasGraph && !hasAnnotations)
+                return graphBounds;
+
+            int xMin = int.MaxValue;
+            int yMin = int.MaxValue;
+            int xMax = int.MinValue;
+            int yMax = int.MinValue;
+
+            if (hasGraph)
+                Include(graphBounds, ref xMin, ref yMin, ref xMax, ref yMax);
+
+            foreach (Rectangle annotation in annotations)
+                Include(annotation, ref xMin, ref yMin, ref xMax, ref yMax);
+
+            int pad = hasGraph ? 0 : AnnotationOnlyPadding;
+            return new Rectangle(
+                xMin - pad,
+                yMin - pad,
+                xMax - xMin + (2 * pad),
+                yMax - yMin + (2 * pad));
+        }
+
+        public static int ScaledWidth(Rectangle bounds, float scale) =>
+            Math.Max(1, (int)Math.Ceiling(bounds.Width * scale));
+
+        public static int ScaledHeight(Rectangle bounds, float scale) =>
+            Math.Max(1, (int)Math.Ceiling(bounds.Height * scale));
+
+        private static void Include(Rectangle r, ref int xMin, ref int yMin, ref int xMax, ref int yMax) {
+            xMin = Math.Min(xMin, r.Left);
+            yMin = Math.Min(yMin, r.Top);
+            xMax = Math.Max(xMax, r.Right);
+            yMax = Math.Max(yMax, r.Bottom);
+        }
+    }
+}

--- a/Foreman/ProductionGraphView/Annotations/TextAnnotationLayout.cs
+++ b/Foreman/ProductionGraphView/Annotations/TextAnnotationLayout.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Drawing;
+
+namespace Foreman {
+    /// <summary>Font/box sizing math for <see cref="TextAnnotationElement"/>.</summary>
+    public static class TextAnnotationLayout {
+        public const int DefaultPadding = 16;
+        public const int MinBoxWidth = 60;
+        public const int MinBoxHeight = 30;
+        public const float MinFontSizePt = 6f;
+        public const float MaxFontSizePt = 288f;
+
+        public static Size MeasureBoxForText(
+            string text,
+            Font font,
+            int padding = DefaultPadding,
+            int minWidth = MinBoxWidth,
+            int minHeight = MinBoxHeight) {
+            if (string.IsNullOrEmpty(text))
+                return new Size(minWidth, minHeight);
+
+            using var bitmap = new Bitmap(1, 1);
+            using var graphics = Graphics.FromImage(bitmap);
+            SizeF natural = graphics.MeasureString(text, font);
+            return new Size(
+                Math.Max(minWidth, (int)Math.Ceiling(natural.Width) + padding),
+                Math.Max(minHeight, (int)Math.Ceiling(natural.Height) + padding));
+        }
+
+        public static float ComputeResizeFontSize(
+            float startFontSizePt,
+            int startWidth,
+            int startHeight,
+            int newWidth,
+            int newHeight) {
+            if (startWidth <= 0 || startHeight <= 0)
+                return startFontSizePt;
+
+            float scale = (float)Math.Sqrt(
+                (newWidth / (double)startWidth) * (newHeight / (double)startHeight));
+            return Math.Clamp(startFontSizePt * scale, MinFontSizePt, MaxFontSizePt);
+        }
+
+        public static bool NearlyEqualFontSize(float a, float b) =>
+            Math.Abs(a - b) < 0.05f;
+    }
+}

--- a/Foreman/ProductionGraphView/Elements/AnnotationElement.cs
+++ b/Foreman/ProductionGraphView/Elements/AnnotationElement.cs
@@ -1,0 +1,498 @@
+﻿using System;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace Foreman {
+    /// <summary>
+    /// Abstract base for all annotation elements (shapes and text labels).
+    /// Annotations live in ProductionGraphViewer, not in the graph model.
+    /// Coordinate conventions follow GraphElement: X,Y is the element center
+    /// in graph space; Bounds is local (0,0 at center).
+    /// </summary>
+    public abstract class AnnotationElement : GraphElement {
+        // ----------------------------------------------------------------
+        // Selection state
+        // ----------------------------------------------------------------
+
+        /// <summary>True when this annotation is part of the current selection set.</summary>
+        public bool IsSelected { get; set; }
+        private const float EdgeHitScreenPx = 8f; // clickable border width in screen pixels
+
+        // ----------------------------------------------------------------
+        // Drag / resize tracking
+        // ----------------------------------------------------------------
+
+        private Point _dragStartMouseLocation;
+        private Point _dragStartElementLocation;
+        private bool _dragStarted;
+
+        // ----------------------------------------------------------------
+        // Resize handle state
+        // ----------------------------------------------------------------
+
+        protected enum HandleType {
+            None,
+            TopLeft, TopCenter, TopRight,
+            MiddleLeft, MiddleRight,
+            BottomLeft, BottomCenter, BottomRight
+        }
+
+        private HandleType _activeHandle = HandleType.None;
+        private int _dragStartWidth;
+        private int _dragStartHeight;
+
+        private const float HandleDrawScreenPx = 5f;  // visual size in screen pixels
+        private const float HandleHitScreenPx = 10f; // hit zone in screen pixels
+
+        /// <summary>True while a resize handle is being dragged (not a move).</summary>
+        public bool IsResizing => _activeHandle != HandleType.None;
+
+        protected int ResizeStartWidth => _dragStartWidth;
+        protected int ResizeStartHeight => _dragStartHeight;
+
+        private const int MinAnnotationSize = 30; // minimum width or height in graph units
+
+        // ----------------------------------------------------------------
+        // Selection highlight visual
+        // ----------------------------------------------------------------
+
+        private const float SelectionHighlightScreenPx = 2.5f;
+        private static readonly Color SelectionHighlightColor = Color.FromArgb(220, 80, 160, 255);
+
+        // ----------------------------------------------------------------
+        // Construction
+        // ----------------------------------------------------------------
+
+        protected AnnotationElement(ProductionGraphViewer graphViewer,
+                                    Point graphLocation, int width, int height)
+            : base(graphViewer) {
+            X = graphLocation.X;
+            Y = graphLocation.Y;
+            Width = width;
+            Height = height;
+
+            IsSelected = false;
+            _dragStarted = false;
+        }
+
+        // ----------------------------------------------------------------
+        // Hit testing ? override to include resize handle areas
+        // ----------------------------------------------------------------
+
+        public override bool ContainsPoint(Point graph_point) {
+            if (!Visible)
+                return false;
+
+            // Resize handles sit outside bounds ? check them first when selected
+            if (IsSelected && GetHandleAtPoint(graph_point) != HandleType.None)
+                return true;
+
+            Point local = GraphToLocal(graph_point);
+
+            if (!Bounds.Contains(local))
+                return false;
+
+            // When selected, the full interior is clickable for dragging
+            if (IsSelected)
+                return true;
+
+            // When unselected, only the edge band counts ? clicking inside
+            // the hollow interior falls through to rubber-band selection
+            float edge = EdgeHitScreenPx / graphViewer.ViewScale;
+            int halfW = Width / 2;
+            int halfH = Height / 2;
+
+            return local.X <= -halfW + edge ||
+                       local.X >= halfW - edge ||
+                       local.Y <= -halfH + edge ||
+                       local.Y >= halfH - edge;
+        }
+
+        // ----------------------------------------------------------------
+        // Mouse handling
+        // ----------------------------------------------------------------
+
+        public override void MouseDown(Point graph_point, MouseButtons button) {
+            if (button == MouseButtons.Left) {
+                _dragStartMouseLocation = graph_point;
+                _dragStartElementLocation = new Point(X, Y);
+                _dragStartWidth = Width;
+                _dragStartHeight = Height;
+                _dragStarted = false;
+                // Only activate a handle if the annotation is already selected
+                _activeHandle = IsSelected ? GetHandleAtPoint(graph_point) : HandleType.None;
+
+                // Only claim the mouse if already selected ? this lets rubber-band
+                // selection start when clicking inside an unselected annotation
+                if (IsSelected)
+                    graphViewer.MouseDownElement = this;
+            }
+        }
+
+        public override void MouseUp(Point graph_point, MouseButtons button, bool wasDragged) {
+            _dragStarted = false;
+            _activeHandle = HandleType.None;
+
+            if (!wasDragged && button == MouseButtons.Right) {
+                RightClickMenu.Items.Clear();
+
+                RightClickMenu.Items.Add(new ToolStripMenuItem("Properties", null,
+                    new EventHandler((o, e) => {
+                        RightClickMenu.Close();
+                        ShowPropertiesDialog();
+                    })));
+                RightClickMenu.Items.Add(new ToolStripSeparator());
+
+                bool inSelection = graphViewer.SelectedAnnotations.Any(a => a == this)
+                    && (graphViewer.SelectedNodes.Count > 0 || graphViewer.SelectedAnnotations.Count > 1);
+                RightClickMenu.Items.Add(new ToolStripMenuItem(inSelection ? "Delete selection" : "Delete", null,
+                    new EventHandler((o, e) => {
+                        RightClickMenu.Close();
+                        if (inSelection)
+                            graphViewer.TryDeleteSelection();
+                        else {
+                            graphViewer.RemoveAnnotationElement(this);
+                        }
+                    })));
+
+                RightClickMenu.Show(graphViewer, graphViewer.GraphToScreen(graph_point));
+            }
+        }
+
+        public override void Dragged(Point graph_point) {
+            // First call after minDragDiff is confirmed ? skip to avoid snap
+            if (!_dragStarted) {
+                _dragStarted = true;
+                return;
+            }
+
+            if (_activeHandle == HandleType.None) {
+                // Move ? offset from original click position
+                Point offset = Point.Subtract(graph_point, (Size)_dragStartMouseLocation);
+                X = _dragStartElementLocation.X + offset.X;
+                Y = _dragStartElementLocation.Y + offset.Y;
+            } else {
+                // Resize
+                ApplyResize(graph_point);
+            }
+        }
+
+        public void CancelMouseCapture() {
+            _dragStarted = false;
+            _activeHandle = HandleType.None;
+        }
+
+        // ----------------------------------------------------------------
+        // Resize math
+        // ----------------------------------------------------------------
+
+        private void ApplyResize(Point mouseGraph) {
+            // Compute movement delta from the original click point
+            int dx = mouseGraph.X - _dragStartMouseLocation.X;
+            int dy = mouseGraph.Y - _dragStartMouseLocation.Y;
+
+            // Snapshot edges (graph coordinates)
+            int startLeft = _dragStartElementLocation.X - _dragStartWidth / 2;
+            int startRight = _dragStartElementLocation.X + _dragStartWidth / 2;
+            int startTop = _dragStartElementLocation.Y - _dragStartHeight / 2;
+            int startBottom = _dragStartElementLocation.Y + _dragStartHeight / 2;
+
+            int newLeft = startLeft;
+            int newRight = startRight;
+            int newTop = startTop;
+            int newBottom = startBottom;
+
+            switch (_activeHandle) {
+                case HandleType.TopLeft:
+                    newLeft = startLeft + dx;
+                    newTop = startTop + dy;
+                    break;
+                case HandleType.TopCenter:
+                    newTop = startTop + dy;
+                    break;
+                case HandleType.TopRight:
+                    newRight = startRight + dx;
+                    newTop = startTop + dy;
+                    break;
+                case HandleType.MiddleLeft:
+                    newLeft = startLeft + dx;
+                    break;
+                case HandleType.MiddleRight:
+                    newRight = startRight + dx;
+                    break;
+                case HandleType.BottomLeft:
+                    newLeft = startLeft + dx;
+                    newBottom = startBottom + dy;
+                    break;
+                case HandleType.BottomCenter:
+                    newBottom = startBottom + dy;
+                    break;
+                case HandleType.BottomRight:
+                    newRight = startRight + dx;
+                    newBottom = startBottom + dy;
+                    break;
+            }
+
+            // Enforce minimum width ? clamp the moving edge
+            if (newRight - newLeft < MinAnnotationSize) {
+                bool movingLeft = _activeHandle == HandleType.TopLeft ||
+                                  _activeHandle == HandleType.MiddleLeft ||
+                                  _activeHandle == HandleType.BottomLeft;
+                if (movingLeft)
+                    newLeft = newRight - MinAnnotationSize;
+                else
+                    newRight = newLeft + MinAnnotationSize;
+            }
+
+            // Enforce minimum height ? clamp the moving edge
+            if (newBottom - newTop < MinAnnotationSize) {
+                bool movingTop = _activeHandle == HandleType.TopLeft ||
+                                 _activeHandle == HandleType.TopCenter ||
+                                 _activeHandle == HandleType.TopRight;
+                if (movingTop)
+                    newTop = newBottom - MinAnnotationSize;
+                else
+                    newBottom = newTop + MinAnnotationSize;
+            }
+
+            Width = newRight - newLeft;
+            Height = newBottom - newTop;
+            X = newLeft + Width / 2;
+            Y = newTop + Height / 2;
+            OnResized();
+        }
+
+        /// <summary>Called after bounds change from a resize-handle drag.</summary>
+        protected virtual void OnResized() { }
+
+        // ----------------------------------------------------------------
+        // Resize handle geometry
+        // ----------------------------------------------------------------
+
+        // Visual size ? small and unobtrusive
+        private int GetHandleDrawHalfSize() {
+            float elementCap = Math.Min(Width, Height) / 5f;
+            return (int)Math.Max(3f, Math.Min(HandleDrawScreenPx / graphViewer.ViewScale, Math.Max(elementCap, 4f)));
+        }
+
+        // Hit-test size ? much larger so handles are easy to click
+        private int GetHandleHitHalfSize() {
+            float elementCap = Math.Min(Width, Height) / 4f;
+            return (int)Math.Max(5f, Math.Min(HandleHitScreenPx / graphViewer.ViewScale, Math.Max(elementCap, 6f)));
+        }
+
+        private Rectangle GetHandleRect(HandleType handle, int half) {
+            int size = half * 2;
+
+            // Anchor points in graph space
+            int cx = X, cy = Y;
+            int left = cx - Width / 2;
+            int right = cx + Width / 2;
+            int top = cy - Height / 2;
+            int bottom = cy + Height / 2;
+
+            switch (handle) {
+                case HandleType.TopLeft:
+                    return new Rectangle(left - half, top - half, size, size);
+                case HandleType.TopCenter:
+                    return new Rectangle(cx - half, top - half, size, size);
+                case HandleType.TopRight:
+                    return new Rectangle(right - half, top - half, size, size);
+                case HandleType.MiddleLeft:
+                    return new Rectangle(left - half, cy - half, size, size);
+                case HandleType.MiddleRight:
+                    return new Rectangle(right - half, cy - half, size, size);
+                case HandleType.BottomLeft:
+                    return new Rectangle(left - half, bottom - half, size, size);
+                case HandleType.BottomCenter:
+                    return new Rectangle(cx - half, bottom - half, size, size);
+                case HandleType.BottomRight:
+                    return new Rectangle(right - half, bottom - half, size, size);
+                default:
+                    return Rectangle.Empty;
+            }
+        }
+
+        protected HandleType GetHandleAtPoint(Point graphPoint) {
+            if (!IsSelected)
+                return HandleType.None;
+
+            HandleType[] handles = {
+                HandleType.TopLeft,    HandleType.TopCenter,    HandleType.TopRight,
+                HandleType.MiddleLeft, HandleType.MiddleRight,
+                HandleType.BottomLeft, HandleType.BottomCenter, HandleType.BottomRight
+            };
+
+            int hitHalf = GetHandleHitHalfSize();
+            foreach (HandleType handle in handles)
+                if (GetHandleRect(handle, hitHalf).Contains(graphPoint))
+                    return handle;
+
+            return HandleType.None;
+        }
+
+        // ----------------------------------------------------------------
+        // Drawing helpers for subclasses
+        // ----------------------------------------------------------------
+
+        /// <summary>
+        /// Returns the bounding rectangle in graph coordinates (top-left + size),
+        /// ready to pass directly to GDI drawing calls.
+        /// </summary>
+        protected Rectangle GetGraphRect() {
+            Point topLeft = LocalToGraph(new Point(-Width / 2, -Height / 2));
+            return new Rectangle(topLeft.X, topLeft.Y, Width, Height);
+        }
+
+        /// <summary>
+        /// Draws the selection highlight border around graphRect.
+        /// Call first inside subclass Draw() so the highlight sits behind the shape.
+        /// </summary>
+        protected void DrawSelectionHighlight(Graphics graphics, Rectangle graphRect) {
+            if (!IsSelected)
+                return;
+
+            float pw = SelectionHighlightScreenPx / graphViewer.ViewScale;
+            using (Pen p = new Pen(SelectionHighlightColor, pw)) {
+                graphics.DrawRectangle(p,
+                    graphRect.X - pw,
+                    graphRect.Y - pw,
+                    graphRect.Width + pw * 2,
+                    graphRect.Height + pw * 2);
+            }
+        }
+
+        /// <summary>
+        /// Draws the 8 resize handles when the annotation is selected.
+        /// Call at the end of each subclass Draw() method.
+        /// </summary>
+        protected void DrawResizeHandles(Graphics graphics) {
+            if (!IsSelected)
+                return;
+
+            float penWidth = Math.Max(0.5f, 1f / graphViewer.ViewScale);
+
+            using (SolidBrush fill = new SolidBrush(Color.White))
+            using (Pen border = new Pen(Color.FromArgb(60, 100, 200), penWidth)) {
+                HandleType[] handles = {
+                    HandleType.TopLeft,    HandleType.TopCenter,    HandleType.TopRight,
+                    HandleType.MiddleLeft, HandleType.MiddleRight,
+                    HandleType.BottomLeft, HandleType.BottomCenter, HandleType.BottomRight
+                };
+
+                int drawHalf = GetHandleDrawHalfSize();
+                foreach (HandleType handle in handles) {
+                    Rectangle r = GetHandleRect(handle, drawHalf);
+                    graphics.FillRectangle(fill, r);
+                    graphics.DrawRectangle(border, r);
+                }
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // Public accessor for the graph viewer (used by property forms)
+        // ----------------------------------------------------------------
+
+        /// <summary>Exposes the graph viewer so property forms can do live updates.</summary>
+        public ProductionGraphViewer GraphViewer => graphViewer;
+
+        // ----------------------------------------------------------------
+        // Abstract interface
+        // ----------------------------------------------------------------
+
+        public abstract AnnotationSaveData ToSaveData();
+        public abstract void ShowPropertiesDialog();
+
+        public static AnnotationElement FromSaveData(AnnotationSaveData data, ProductionGraphViewer graphViewer) =>
+            data switch {
+                TextAnnotationSaveData text => TextAnnotationElement.FromSaveData(text, graphViewer),
+                ShapeAnnotationSaveData shape => ShapeAnnotationElement.FromSaveData(shape, graphViewer),
+                _ => throw new InvalidOperationException("Unknown annotation type in save: " + data.Type)
+            };
+
+        protected static ColorSaveData ColorToSave(Color c) => new(c.A, c.R, c.G, c.B);
+
+        protected static Color ColorFromSave(ColorSaveData c) => Color.FromArgb(c.A, c.R, c.G, c.B);
+
+        /// <summary>
+        /// Returns true if the lasso rectangle intersects the EDGE of this annotation ?
+        /// i.e. overlaps the bounding box but is not entirely contained within it.
+        /// This prevents a lasso drawn entirely inside a shape from selecting it.
+        /// </summary>
+        public bool LassoIntersectsEdge(Rectangle lasso) {
+            // Compute annotation bounds in graph space
+            int annLeft = X - Width / 2;
+            int annRight = X + Width / 2;
+            int annTop = Y - Height / 2;
+            int annBottom = Y + Height / 2;
+
+            // Must overlap the annotation at all
+            bool overlaps = lasso.Right > annLeft &&
+                            lasso.Left < annRight &&
+                            lasso.Bottom > annTop &&
+                            lasso.Top < annBottom;
+
+            if (!overlaps)
+                return false;
+
+            // Lasso is entirely inside the annotation ? don't select
+            bool lassoInsideAnnotation = lasso.Left >= annLeft &&
+                                         lasso.Right <= annRight &&
+                                         lasso.Top >= annTop &&
+                                         lasso.Bottom <= annBottom;
+
+            return !lassoInsideAnnotation;
+        }
+
+        public bool ContainsPointFull(Point graph_point) {
+            if (!Visible)
+                return false;
+            return Bounds.Contains(GraphToLocal(graph_point));
+        }
+
+        /// <summary>Hit-test for mouse picking. When selected, includes resize handles drawn outside bounds.</summary>
+        public bool PickAtPoint(Point graph_point) =>
+            IsSelected ? ContainsPoint(graph_point) : ContainsPointFull(graph_point);
+
+        /// <summary>Forces this annotation to be visible regardless of bounds check.
+        /// Used during full-graph export so off-graph annotations aren't clipped.</summary>
+        public void ForceVisible() { Visible = true; }
+
+        /// <summary>
+        /// Returns the appropriate cursor when the mouse is at the given graph point,
+        /// or null if this annotation doesn't own that point.
+        /// </summary>
+        public Cursor? GetCursorForPoint(Point graphPoint) {
+            if (!Visible)
+                return null;
+
+            if (IsSelected) {
+                switch (GetHandleAtPoint(graphPoint)) {
+                    case HandleType.TopLeft:
+                    case HandleType.BottomRight:
+                        return Cursors.SizeNWSE;
+                    case HandleType.TopRight:
+                    case HandleType.BottomLeft:
+                        return Cursors.SizeNESW;
+                    case HandleType.TopCenter:
+                    case HandleType.BottomCenter:
+                        return Cursors.SizeNS;
+                    case HandleType.MiddleLeft:
+                    case HandleType.MiddleRight:
+                        return Cursors.SizeWE;
+                }
+
+                // Inside selected annotation ? move cursor
+                if (Bounds.Contains(GraphToLocal(graphPoint)))
+                    return Cursors.SizeAll;
+            }
+
+            // Edge band (shapes) or full bounds (text) ? move cursor
+            if (ContainsPoint(graphPoint))
+                return Cursors.SizeAll;
+
+            return null;
+        }
+    }
+}

--- a/Foreman/ProductionGraphView/Elements/ShapeAnnotationElement.cs
+++ b/Foreman/ProductionGraphView/Elements/ShapeAnnotationElement.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Windows.Forms;
+
+namespace Foreman {
+    /// <summary>Rectangle or ellipse annotation on the canvas.</summary>
+    public class ShapeAnnotationElement : AnnotationElement {
+        public enum ShapeType { Rectangle, Ellipse }
+
+        private const int DefaultWidth = 200;
+        private const int DefaultHeight = 150;
+
+        public ShapeType CurrentShapeType { get; set; }
+        public Color FillColor { get; set; }
+        public Color BorderColor { get; set; }
+        public int BorderWidth { get; set; }
+
+        private SolidBrush? _fillBrush;
+        private Pen? _borderPen;
+
+        private static ShapeType _defaultShapeType = (ShapeType)Properties.Settings.Default.AnnotShapeType;
+        private static Color _defaultFillColor = Color.FromArgb(Properties.Settings.Default.AnnotShapeFillColorARGB);
+        private static Color _defaultBorderColor = Color.FromArgb(Properties.Settings.Default.AnnotShapeBorderColorARGB);
+        private static int _defaultBorderWidth = Properties.Settings.Default.AnnotShapeBorderWidth;
+
+        public static void SaveDefaults(ShapeAnnotationElement element) {
+            _defaultShapeType = element.CurrentShapeType;
+            _defaultFillColor = element.FillColor;
+            _defaultBorderColor = element.BorderColor;
+            _defaultBorderWidth = element.BorderWidth;
+
+            var s = Properties.Settings.Default;
+            s.AnnotShapeType = (int)_defaultShapeType;
+            s.AnnotShapeFillColorARGB = _defaultFillColor.ToArgb();
+            s.AnnotShapeBorderColorARGB = _defaultBorderColor.ToArgb();
+            s.AnnotShapeBorderWidth = _defaultBorderWidth;
+            s.Save();
+        }
+
+        public ShapeAnnotationElement(ProductionGraphViewer graphViewer, Point graphLocation)
+            : base(graphViewer, graphLocation, DefaultWidth, DefaultHeight) {
+            ApplyDefaults();
+        }
+
+        public ShapeAnnotationElement(ProductionGraphViewer graphViewer, Point graphLocation, int width, int height)
+            : base(graphViewer, graphLocation, width, height) {
+            ApplyDefaults();
+        }
+
+        private void ApplyDefaults() {
+            CurrentShapeType = _defaultShapeType;
+            FillColor = _defaultFillColor;
+            BorderColor = _defaultBorderColor;
+            BorderWidth = _defaultBorderWidth;
+            RebuildGdiObjects();
+        }
+
+        private ShapeAnnotationElement(ProductionGraphViewer graphViewer,
+            Point location, Size size, ShapeType shapeType,
+            Color fillColor, Color borderColor, int borderWidth)
+            : base(graphViewer, location, size.Width, size.Height) {
+            CurrentShapeType = shapeType;
+            FillColor = fillColor;
+            BorderColor = borderColor;
+            BorderWidth = borderWidth;
+            RebuildGdiObjects();
+        }
+
+        public void RebuildGdiObjects() {
+            _fillBrush?.Dispose();
+            _borderPen?.Dispose();
+            _fillBrush = new SolidBrush(FillColor);
+            _borderPen = new Pen(BorderColor, Math.Max(1, BorderWidth)) { Alignment = PenAlignment.Inset };
+        }
+
+        protected override void Draw(Graphics graphics, NodeDrawingStyle style) {
+            Rectangle r = GetGraphRect();
+            DrawSelectionHighlight(graphics, r);
+
+            if (FillColor.A > 0 && _fillBrush is not null) {
+                switch (CurrentShapeType) {
+                    case ShapeType.Rectangle:
+                        graphics.FillRectangle(_fillBrush, r);
+                        break;
+                    case ShapeType.Ellipse:
+                        graphics.FillEllipse(_fillBrush, r);
+                        break;
+                }
+            }
+
+            if (BorderWidth > 0 && BorderColor.A > 0 && _borderPen is not null) {
+                switch (CurrentShapeType) {
+                    case ShapeType.Rectangle:
+                        graphics.DrawRectangle(_borderPen, r);
+                        break;
+                    case ShapeType.Ellipse:
+                        graphics.DrawEllipse(_borderPen, r);
+                        break;
+                }
+            }
+
+            DrawResizeHandles(graphics);
+        }
+
+        public override void ShowPropertiesDialog() {
+            using var form = new ShapePropertiesForm(this);
+            form.StartPosition = FormStartPosition.CenterParent;
+            if (form.ShowDialog(graphViewer.FindForm()) == DialogResult.OK) {
+                RebuildGdiObjects();
+                graphViewer.Invalidate();
+            }
+        }
+
+        public override AnnotationSaveData ToSaveData() => new ShapeAnnotationSaveData {
+            X = X,
+            Y = Y,
+            Width = Width,
+            Height = Height,
+            ShapeType = CurrentShapeType.ToString(),
+            FillColor = ColorToSave(FillColor),
+            BorderColor = ColorToSave(BorderColor),
+            BorderWidth = BorderWidth
+        };
+
+        public static ShapeAnnotationElement FromSaveData(ShapeAnnotationSaveData data, ProductionGraphViewer graphViewer) {
+            var shapeType = Enum.TryParse<ShapeType>(data.ShapeType, out ShapeType parsed)
+                ? parsed
+                : ShapeType.Rectangle;
+            return new ShapeAnnotationElement(
+                graphViewer,
+                new Point(data.X, data.Y),
+                new Size(data.Width, data.Height),
+                shapeType,
+                ColorFromSave(data.FillColor),
+                ColorFromSave(data.BorderColor),
+                data.BorderWidth);
+        }
+
+        public override void Dispose() {
+            _fillBrush?.Dispose();
+            _borderPen?.Dispose();
+            base.Dispose();
+        }
+    }
+}

--- a/Foreman/ProductionGraphView/Elements/TextAnnotationElement.cs
+++ b/Foreman/ProductionGraphView/Elements/TextAnnotationElement.cs
@@ -1,0 +1,212 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Foreman {
+    /// <summary>Freehand text label on the canvas, centred inside element bounds.</summary>
+    public class TextAnnotationElement : AnnotationElement {
+        private const int DefaultWidth = 200;
+        private const int DefaultHeight = 60;
+
+        public string Text { get; set; }
+        public Font TextFont { get; set; }
+        public Color TextColor { get; set; }
+        public Color BackColor { get; set; }
+        public StringAlignment TextAlign { get; set; }
+
+        private SolidBrush? _textBrush;
+        private SolidBrush? _backBrush;
+        private StringFormat? _textFormat;
+        private float _resizeStartFontSize;
+
+        private static string _defaultFontFamily = Properties.Settings.Default.AnnotTextFontFamily;
+        private static float _defaultFontSize = float.TryParse(Properties.Settings.Default.AnnotTextFontSize, out float fs) ? fs : 14f;
+        private static FontStyle _defaultFontStyle = (FontStyle)Properties.Settings.Default.AnnotTextFontStyle;
+        private static Color _defaultTextColor = Color.FromArgb(Properties.Settings.Default.AnnotTextColorARGB);
+        private static Color _defaultBackColor = Color.FromArgb(Properties.Settings.Default.AnnotTextBackColorARGB);
+        private static StringAlignment _defaultTextAlign = (StringAlignment)Properties.Settings.Default.AnnotTextAlign;
+
+        public static void SaveDefaults(TextAnnotationElement element) {
+            _defaultFontFamily = element.TextFont.FontFamily.Name;
+            _defaultFontSize = element.TextFont.SizeInPoints;
+            _defaultFontStyle = element.TextFont.Style;
+            _defaultTextColor = element.TextColor;
+            _defaultBackColor = element.BackColor;
+            _defaultTextAlign = element.TextAlign;
+
+            var settings = Properties.Settings.Default;
+            settings.AnnotTextFontFamily = _defaultFontFamily;
+            settings.AnnotTextFontSize = _defaultFontSize.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            settings.AnnotTextFontStyle = (int)_defaultFontStyle;
+            settings.AnnotTextColorARGB = _defaultTextColor.ToArgb();
+            settings.AnnotTextBackColorARGB = _defaultBackColor.ToArgb();
+            settings.AnnotTextAlign = (int)_defaultTextAlign;
+            settings.Save();
+        }
+
+        public TextAnnotationElement(ProductionGraphViewer graphViewer, Point graphLocation)
+            : base(graphViewer, graphLocation, DefaultWidth, DefaultHeight) {
+            Text = "Label";
+            TextFont = CreateDefaultFont();
+            TextColor = _defaultTextColor;
+            BackColor = _defaultBackColor;
+            TextAlign = _defaultTextAlign;
+            RebuildGdiObjects();
+            FitBoxToTextAtCenter();
+        }
+
+        private TextAnnotationElement(
+            ProductionGraphViewer graphViewer,
+            Point location,
+            Size size,
+            string text,
+            Font textFont,
+            Color textColor,
+            Color backColor,
+            StringAlignment textAlign)
+            : base(graphViewer, location, size.Width, size.Height) {
+            Text = text;
+            TextFont = textFont;
+            TextColor = textColor;
+            BackColor = backColor;
+            TextAlign = textAlign;
+            RebuildGdiObjects();
+        }
+
+        private static Font CreateDefaultFont() {
+            try {
+                return new Font(_defaultFontFamily, _defaultFontSize, _defaultFontStyle, GraphicsUnit.Point);
+            } catch {
+                return new Font("Segoe UI", 14f, FontStyle.Bold, GraphicsUnit.Point);
+            }
+        }
+
+        /// <summary>Measures text and sets Width/Height around the unchanged center (X, Y).</summary>
+        public void FitBoxToTextAtCenter() {
+            Size box = TextAnnotationLayout.MeasureBoxForText(Text, TextFont);
+            Width = box.Width;
+            Height = box.Height;
+        }
+
+        public void SetFontSizeInPoints(float sizeInPoints) {
+            sizeInPoints = Math.Clamp(sizeInPoints, TextAnnotationLayout.MinFontSizePt, TextAnnotationLayout.MaxFontSizePt);
+            if (TextAnnotationLayout.NearlyEqualFontSize(TextFont.SizeInPoints, sizeInPoints))
+                return;
+
+            Font previous = TextFont;
+            TextFont = new Font(previous.FontFamily, sizeInPoints, previous.Style, GraphicsUnit.Point);
+            previous.Dispose();
+            RebuildGdiObjects();
+        }
+
+        public override void MouseDown(Point graph_point, MouseButtons button) {
+            base.MouseDown(graph_point, button);
+            if (button == MouseButtons.Left && IsResizing)
+                _resizeStartFontSize = TextFont.SizeInPoints;
+        }
+
+        protected override void OnResized() {
+            float newSize = TextAnnotationLayout.ComputeResizeFontSize(
+                _resizeStartFontSize,
+                ResizeStartWidth,
+                ResizeStartHeight,
+                Width,
+                Height);
+            SetFontSizeInPoints(newSize);
+        }
+
+        public void RebuildGdiObjects() {
+            DisposeGdiObjects();
+
+            _textBrush = new SolidBrush(TextColor);
+            _backBrush = BackColor.A > 0 ? new SolidBrush(BackColor) : null;
+            _textFormat = new StringFormat {
+                Alignment = TextAlign,
+                LineAlignment = StringAlignment.Center,
+                Trimming = StringTrimming.None,
+                FormatFlags = StringFormatFlags.NoWrap
+            };
+        }
+
+        private void DisposeGdiObjects() {
+            _textBrush?.Dispose();
+            _backBrush?.Dispose();
+            _textFormat?.Dispose();
+            _textBrush = null;
+            _backBrush = null;
+            _textFormat = null;
+        }
+
+        public override bool ContainsPoint(Point graph_point) {
+            if (!Visible)
+                return false;
+            if (IsSelected && GetHandleAtPoint(graph_point) != HandleType.None)
+                return true;
+            return Bounds.Contains(GraphToLocal(graph_point));
+        }
+
+        protected override void Draw(Graphics graphics, NodeDrawingStyle style) {
+            Rectangle bounds = GetGraphRect();
+            DrawSelectionHighlight(graphics, bounds);
+
+            if (_backBrush is not null)
+                graphics.FillRectangle(_backBrush, bounds);
+
+            if (!string.IsNullOrEmpty(Text) && _textBrush is not null && _textFormat is not null)
+                graphics.DrawString(Text, TextFont, _textBrush, (RectangleF)bounds, _textFormat);
+
+            DrawResizeHandles(graphics);
+        }
+
+        public override void ShowPropertiesDialog() {
+            using var form = new TextPropertiesForm(this);
+            form.StartPosition = FormStartPosition.CenterParent;
+            if (form.ShowDialog(graphViewer.FindForm()) == DialogResult.OK) {
+                RebuildGdiObjects();
+                graphViewer.Invalidate();
+            }
+        }
+
+        public override AnnotationSaveData ToSaveData() => new TextAnnotationSaveData {
+            X = X,
+            Y = Y,
+            Width = Width,
+            Height = Height,
+            Text = Text,
+            FontFamily = TextFont.FontFamily.Name,
+            FontSize = TextFont.SizeInPoints,
+            FontStyle = (int)TextFont.Style,
+            TextColor = ColorToSave(TextColor),
+            BackColor = ColorToSave(BackColor),
+            TextAlign = (int)TextAlign
+        };
+
+        public static TextAnnotationElement FromSaveData(TextAnnotationSaveData data, ProductionGraphViewer graphViewer) {
+            Font font = TryCreateFont(data.FontFamily, data.FontSize, (FontStyle)data.FontStyle);
+            var align = data.TextAlign is >= 0 and <= 2 ? (StringAlignment)data.TextAlign : StringAlignment.Center;
+            return new TextAnnotationElement(
+                graphViewer,
+                new Point(data.X, data.Y),
+                new Size(data.Width, data.Height),
+                data.Text,
+                font,
+                ColorFromSave(data.TextColor),
+                ColorFromSave(data.BackColor),
+                align);
+        }
+
+        private static Font TryCreateFont(string family, float size, FontStyle style) {
+            try {
+                return new Font(family, size, style, GraphicsUnit.Point);
+            } catch {
+                return new Font("Segoe UI", 14f, FontStyle.Bold, GraphicsUnit.Point);
+            }
+        }
+
+        public override void Dispose() {
+            DisposeGdiObjects();
+            TextFont.Dispose();
+            base.Dispose();
+        }
+    }
+}

--- a/Foreman/ProductionGraphView/ProductionGraphViewer.Annotations.cs
+++ b/Foreman/ProductionGraphView/ProductionGraphViewer.Annotations.cs
@@ -1,0 +1,427 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace Foreman {
+    public partial class ProductionGraphViewer {
+        private static readonly Pen drawShapePen = new(Color.FromArgb(200, 60, 120, 220), 2) {
+            DashStyle = DashStyle.Dash
+        };
+
+        private List<AnnotationElement> annotationElements = [];
+        private HashSet<AnnotationElement> selectedAnnotations = [];
+        private bool inDrawShapeMode;
+
+        public IReadOnlyCollection<AnnotationElement> SelectedAnnotations => selectedAnnotations;
+
+        private void ClearAnnotations() {
+            foreach (AnnotationElement ann in annotationElements.ToList())
+                ann.Dispose();
+            annotationElements.Clear();
+            selectedAnnotations.Clear();
+            inDrawShapeMode = false;
+        }
+
+        public IReadOnlyList<AnnotationSaveData> GetAnnotationSaveData() =>
+            annotationElements.Select(a => a.ToSaveData()).ToList();
+
+        /// <summary>Graph-space bounds for full-graph image export (nodes/links and annotations).</summary>
+        public Rectangle GetExportBounds() =>
+            GraphExportBounds.Compute(
+                Graph.Bounds,
+                annotationElements.Select(GraphExportBounds.GetGraphBounds));
+
+        public void LoadAnnotationsFromSave(IReadOnlyList<AnnotationSaveData> annotations, int? savedDpi) {
+            ClearAnnotations();
+            if (annotations.Count == 0)
+                return;
+
+            float dpiScale = 1f;
+            if (savedDpi is int dpi && dpi > 0)
+                dpiScale = DeviceDpi / (float)dpi;
+
+            foreach (AnnotationSaveData data in annotations) {
+                if (TryCreateAnnotationFromSave(data, dpiScale, out AnnotationElement? ann))
+                    AddAnnotationElement(ann);
+            }
+        }
+
+        private bool TryCreateAnnotationFromSave(
+            AnnotationSaveData data,
+            float dpiScale,
+            [NotNullWhen(true)] out AnnotationElement? annotation) {
+            annotation = null;
+            try {
+                annotation = AnnotationElement.FromSaveData(data, this);
+                if (Math.Abs(dpiScale - 1f) > 0.01f && annotation is TextAnnotationElement text) {
+                    text.Width = (int)Math.Round(text.Width * dpiScale);
+                    text.Height = (int)Math.Round(text.Height * dpiScale);
+                }
+                return true;
+            } catch (Exception ex) {
+                ErrorLogging.LogLine($"Skipping bad annotation: {ex.Message}");
+                return false;
+            }
+        }
+
+        public AnnotationElement? GetAnnotationAtPoint(Point point) {
+            for (int i = annotationElements.Count - 1; i >= 0; i--) {
+                if (annotationElements[i].PickAtPoint(point))
+                    return annotationElements[i];
+            }
+            return null;
+        }
+
+        public void AddAnnotationElement(AnnotationElement element) {
+            annotationElements.Add(element);
+            Invalidate();
+        }
+
+        public void RemoveAnnotationElement(AnnotationElement element) {
+            annotationElements.Remove(element);
+            selectedAnnotations.Remove(element);
+            element.Dispose();
+            Invalidate();
+        }
+
+        public void AddShapeAnnotation(Point graphPoint) {
+            inDrawShapeMode = true;
+            Cursor = Cursors.Cross;
+            SelectionZoneOriginPoint = graphPoint;
+            SelectionZone = new Rectangle();
+            Invalidate();
+        }
+
+        public void AddTextAnnotation(Point graphPoint) {
+            var element = new TextAnnotationElement(this, graphPoint);
+            element.IsSelected = true;
+            AddAnnotationElement(element);
+
+            using var form = new TextPropertiesForm(element);
+            form.StartPosition = FormStartPosition.CenterParent;
+            if (form.ShowDialog(FindForm()) == DialogResult.OK) {
+                ClearNodeAndAnnotationSelection(keepAnnotation: element);
+                element.IsSelected = true;
+                Cursor = Cursors.Default;
+                Invalidate();
+            } else {
+                RemoveAnnotationElement(element);
+            }
+        }
+
+        public void TryDeleteSelection() {
+            int total = selectedNodes.Count + selectedAnnotations.Count;
+            if (total == 0)
+                return;
+
+            if (total > 10
+                && UserMessages.Show(
+                    $"You are deleting {total} items.\nAre you sure?",
+                    "Confirm delete.",
+                    MessageBoxButtons.YesNo) != DialogResult.Yes) {
+                return;
+            }
+
+            foreach (BaseNodeElement node in selectedNodes.ToList())
+                Session.Editor.DeleteNode(node.ViewModel.Id);
+            selectedNodes.Clear();
+
+            foreach (AnnotationElement ann in selectedAnnotations.ToList())
+                RemoveAnnotationElement(ann);
+            selectedAnnotations.Clear();
+
+            Graph.UpdateNodeValues();
+        }
+
+        private void ClearAnnotationSelection() {
+            foreach (AnnotationElement ann in selectedAnnotations)
+                ann.IsSelected = false;
+            selectedAnnotations.Clear();
+        }
+
+        private void ClearNodeAndAnnotationSelection(AnnotationElement? keepAnnotation = null) {
+            foreach (BaseNodeElement node in selectedNodes)
+                node.Highlighted = false;
+            selectedNodes.Clear();
+
+            foreach (AnnotationElement ann in selectedAnnotations) {
+                if (ann != keepAnnotation)
+                    ann.IsSelected = false;
+            }
+            selectedAnnotations.Clear();
+            if (keepAnnotation is not null)
+                selectedAnnotations.Add(keepAnnotation);
+        }
+
+        private void CommitAnnotationLassoSelection() =>
+            ApplyAnnotationZoneSelection(GetAnnotationsIntersectingLasso(), commit: true);
+
+        private void UpdateAnnotationLassoPreview() =>
+            ApplyAnnotationZoneSelection(GetAnnotationsIntersectingLasso(), commit: false);
+
+        private HashSet<AnnotationElement> GetAnnotationsIntersectingLasso() =>
+            [.. annotationElements.Where(a => a.LassoIntersectsEdge(SelectionZone))];
+
+        private void ApplyAnnotationZoneSelection(HashSet<AnnotationElement> zoneAnnotations, bool commit) {
+            if (AnnotationSelectionModifiers.IsRemoveFromSelection) {
+                if (commit) {
+                    foreach (AnnotationElement ann in selectedAnnotations.Where(zoneAnnotations.Contains).ToList()) {
+                        ann.IsSelected = false;
+                        selectedAnnotations.Remove(ann);
+                    }
+                } else {
+                    foreach (AnnotationElement ann in annotationElements)
+                        ann.IsSelected = selectedAnnotations.Contains(ann) && !zoneAnnotations.Contains(ann);
+                }
+                return;
+            }
+
+            if (AnnotationSelectionModifiers.IsAddToSelection) {
+                foreach (AnnotationElement ann in annotationElements)
+                    ann.IsSelected = selectedAnnotations.Contains(ann) || zoneAnnotations.Contains(ann);
+                if (commit) {
+                    foreach (AnnotationElement ann in zoneAnnotations)
+                        selectedAnnotations.Add(ann);
+                }
+                return;
+            }
+
+            foreach (AnnotationElement ann in annotationElements)
+                ann.IsSelected = zoneAnnotations.Contains(ann);
+            if (commit) {
+                ClearAnnotationSelection();
+                foreach (AnnotationElement ann in zoneAnnotations) {
+                    ann.IsSelected = true;
+                    selectedAnnotations.Add(ann);
+                }
+            }
+        }
+
+        private void ImportAnnotationsAtOrigin(IReadOnlyList<AnnotationSaveData> annotations, Point origin) {
+            if (annotations.Count == 0)
+                return;
+
+            List<AnnotationElement> imported = [];
+            foreach (AnnotationSaveData data in annotations) {
+                if (TryCreateAnnotationFromSave(data, dpiScale: 1f, out AnnotationElement? ann))
+                    imported.Add(ann);
+            }
+            if (imported.Count == 0)
+                return;
+
+            long xAve = imported.Sum(a => (long)a.X);
+            long yAve = imported.Sum(a => (long)a.Y);
+            xAve /= imported.Count;
+            yAve /= imported.Count;
+            Point offset = new(origin.X - (int)xAve, origin.Y - (int)yAve);
+
+            foreach (AnnotationElement ann in imported) {
+                ann.X += offset.X;
+                ann.Y += offset.Y;
+                ann.IsSelected = true;
+                AddAnnotationElement(ann);
+                selectedAnnotations.Add(ann);
+            }
+        }
+
+        private void ImportAnnotationsWithOffset(IReadOnlyList<AnnotationSaveData> annotations, Size offset) {
+            foreach (AnnotationSaveData data in annotations) {
+                if (!TryCreateAnnotationFromSave(data, dpiScale: 1f, out AnnotationElement? ann))
+                    continue;
+
+                ann.X += offset.Width;
+                ann.Y += offset.Height;
+                ann.IsSelected = true;
+                AddAnnotationElement(ann);
+                selectedAnnotations.Add(ann);
+            }
+        }
+
+        private bool Annotation_OnMouseDown(MouseEventArgs e, Point graph_location, ref GraphElement? clickedElement) {
+            if (e.Clicks >= 2)
+                return false;
+
+            clickedElement ??= GetAnnotationAtPoint(graph_location);
+            clickedElement?.MouseDown(graph_location, e.Button);
+            return false;
+        }
+
+        private bool Annotation_OnMouseDownDoubleClick(MouseEventArgs e, GraphElement? clickedElement) {
+            if (e.Clicks != 2 || e.Button != MouseButtons.Left || clickedElement is not AnnotationElement ann)
+                return false;
+
+            CancelAnnotationMouseCapture(ann);
+            ann.ShowPropertiesDialog();
+            CancelAnnotationMouseCapture(ann);
+            return true;
+        }
+
+        private void CancelAnnotationMouseCapture(AnnotationElement ann) {
+            ann.CancelMouseCapture();
+            MouseDownElement = null;
+            currentDragOperation = DragOperation.None;
+            viewBeingDragged = false;
+            downButtons &= ~MouseButtons.Left;
+        }
+
+        private bool Annotation_FinishDrawShape() {
+            if (currentDragOperation != DragOperation.DrawShape)
+                return false;
+
+            const int minDrawSize = 30;
+            if (SelectionZone.Width >= minDrawSize || SelectionZone.Height >= minDrawSize) {
+                int w = Math.Max(SelectionZone.Width, minDrawSize);
+                int h = Math.Max(SelectionZone.Height, minDrawSize);
+                Point center = new(SelectionZone.Left + w / 2, SelectionZone.Top + h / 2);
+                AddAnnotationElement(new ShapeAnnotationElement(this, center, w, h));
+            } else {
+                AddAnnotationElement(new ShapeAnnotationElement(this, SelectionZoneOriginPoint));
+            }
+
+            inDrawShapeMode = false;
+            Cursor = Cursors.Default;
+            SelectionZone = new Rectangle();
+            return true;
+        }
+
+        private void Annotation_OnMouseUpLeft(Point graph_location, GraphElement? element, bool viewBeingDragged) {
+            if (currentDragOperation == DragOperation.None && MouseDownElement is AnnotationElement clickedAnnotation) {
+                HandleMouseUpOnTrackedAnnotation(clickedAnnotation, viewBeingDragged);
+                return;
+            }
+
+            if (currentDragOperation == DragOperation.None && MouseDownElement is null
+                && element is AnnotationElement unselectedAnnotation && !viewBeingDragged) {
+                SelectSingleAnnotation(unselectedAnnotation);
+            }
+        }
+
+        private void HandleMouseUpOnTrackedAnnotation(AnnotationElement clickedAnnotation, bool viewBeingDragged) {
+            if (AnnotationSelectionModifiers.IsRemoveFromSelection) {
+                selectedAnnotations.Remove(clickedAnnotation);
+                clickedAnnotation.IsSelected = false;
+            } else if (AnnotationSelectionModifiers.IsAddToSelection) {
+                if (clickedAnnotation.IsSelected)
+                    selectedAnnotations.Remove(clickedAnnotation);
+                else
+                    selectedAnnotations.Add(clickedAnnotation);
+                clickedAnnotation.IsSelected = !clickedAnnotation.IsSelected;
+            } else if (!viewBeingDragged) {
+                SelectSingleAnnotation(clickedAnnotation);
+            }
+
+            MouseDownElement = null;
+            Invalidate();
+        }
+
+        private void SelectSingleAnnotation(AnnotationElement annotation) {
+            if (AnnotationSelectionModifiers.IsAddToSelection) {
+                selectedAnnotations.Add(annotation);
+                annotation.IsSelected = true;
+                return;
+            }
+
+            if (AnnotationSelectionModifiers.IsRemoveFromSelection)
+                return;
+
+            ClearNodeAndAnnotationSelection();
+            selectedAnnotations.Add(annotation);
+            annotation.IsSelected = true;
+        }
+
+        private void Annotation_AppendContextMenuItems(Point graph_location) {
+            rightClickMenu.Items.Add(new ToolStripSeparator());
+            rightClickMenu.Items.Add(new ToolStripMenuItem("Add Text", null, (_, _) => {
+                rightClickMenu.Close();
+                AddTextAnnotation(graph_location);
+            }));
+            rightClickMenu.Items.Add(new ToolStripMenuItem("Add Shape", null, (_, _) => {
+                rightClickMenu.Close();
+                AddShapeAnnotation(graph_location);
+            }));
+        }
+
+        private DragOperation Annotation_ResolveDragOperation(DragOperation proposed) {
+            if (inDrawShapeMode && proposed == DragOperation.Selection)
+                return DragOperation.DrawShape;
+            return proposed;
+        }
+
+        private void Annotation_OnItemDrag(Point graph_location) {
+            if (MouseDownElement is not AnnotationElement draggedAnn)
+                return;
+
+            if (selectedAnnotations.Contains(draggedAnn)) {
+                if (draggedAnn.IsResizing) {
+                    draggedAnn.Dragged(graph_location);
+                    return;
+                }
+
+                Point startPoint = draggedAnn.Location;
+                draggedAnn.Dragged(graph_location);
+                Point endPoint = draggedAnn.Location;
+                if (startPoint == endPoint)
+                    return;
+
+                int dx = endPoint.X - startPoint.X;
+                int dy = endPoint.Y - startPoint.Y;
+                foreach (AnnotationElement ann in selectedAnnotations.Where(a => a != draggedAnn)) {
+                    ann.X += dx;
+                    ann.Y += dy;
+                }
+                foreach (BaseNodeElement node in selectedNodes)
+                    node.SetLocation(new Point(node.X + dx, node.Y + dy));
+                Invalidate();
+                return;
+            }
+
+            draggedAnn.Dragged(graph_location);
+        }
+
+        private void Annotation_UpdateCursor(Point graph_location) {
+            if (currentDragOperation == DragOperation.DrawShape
+                || (inDrawShapeMode && currentDragOperation == DragOperation.None)) {
+                Cursor = Cursors.Cross;
+                return;
+            }
+
+            if (currentDragOperation != DragOperation.None || viewBeingDragged)
+                return;
+
+            Cursor = Cursors.Default;
+            for (int i = annotationElements.Count - 1; i >= 0; i--) {
+                Cursor? annCursor = annotationElements[i].GetCursorForPoint(graph_location);
+                if (annCursor is not null) {
+                    Cursor = annCursor;
+                    return;
+                }
+            }
+        }
+
+        private void Annotation_OnKeyDown(KeyEventArgs e) {
+            if (inDrawShapeMode && e.KeyCode == Keys.Escape) {
+                inDrawShapeMode = false;
+                currentDragOperation = DragOperation.None;
+                Cursor = Cursors.Default;
+                SelectionZone = new Rectangle();
+                e.Handled = true;
+            }
+        }
+
+        private void Annotation_OnDeleteKey() {
+            if (selectedAnnotations.Count > 0)
+                TryDeleteSelection();
+        }
+
+        private void Annotation_MoveSelection(int dx, int dy) {
+            foreach (AnnotationElement ann in selectedAnnotations) {
+                ann.X += dx;
+                ann.Y += dy;
+            }
+        }
+    }
+}

--- a/Foreman/ProductionGraphView/ProductionGraphViewer.cs
+++ b/Foreman/ProductionGraphView/ProductionGraphViewer.cs
@@ -9,6 +9,8 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
@@ -17,7 +19,7 @@ namespace Foreman {
     public enum NodeDrawingStyle { Regular, PrintStyle, Simple, IconsOnly } //printstyle is meant for any additional chages (from regular) for exporting to image format, simple will only draw the node boxes (no icons or text) and link lines, iconsonly will draw node icons instead of nodes (for zoomed view)
 
     public partial class ProductionGraphViewer : UserControl {
-        private enum DragOperation { None, Item, Selection }
+        private enum DragOperation { None, Item, Selection, DrawShape }
         public enum LOD { Low, Medium, High } //low: only names. medium: assemblers, beacons, etc. high: include assembler percentages
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -141,6 +143,7 @@ namespace Foreman {
             Graph.ClearGraph();
             //at this point every node element and link element has been removed.
 
+            ClearAnnotations();
             selectedNodes.Clear();
             currentSelectionNodes.Clear();
         }
@@ -586,6 +589,7 @@ namespace Foreman {
                 element.Highlighted = false;
             selectedNodes.Clear();
             currentSelectionNodes.Clear();
+            ClearAnnotationSelection();
             Invalidate();
         }
 
@@ -598,6 +602,8 @@ namespace Foreman {
         //----------------------------------------------Paint functions
 
         protected IEnumerable<GraphElement> GetPaintingOrder() {
+            foreach (AnnotationElement element in annotationElements)
+                yield return element;
             if (draggedLinkElement != null)
                 yield return draggedLinkElement;
             foreach (LinkElement element in linkElements)
@@ -630,10 +636,12 @@ namespace Foreman {
 
         public new void Paint(Graphics graphics, bool FullGraph = false) {
             //update visibility of all elements
-            if (FullGraph)
+            if (FullGraph) {
                 foreach (GraphElement element in GetPaintingOrder())
                     element.UpdateVisibility(Graph.Bounds);
-            else
+                foreach (AnnotationElement ann in annotationElements)
+                    ann.ForceVisible();
+            } else
                 foreach (GraphElement element in GetPaintingOrder())
                     element.UpdateVisibility(VisibleGraphBounds);
 
@@ -678,6 +686,11 @@ namespace Foreman {
             int visibleElements = GetPaintingOrder().Count(e => e.Visible && e is BaseNodeElement);
             foreach (GraphElement element in GetPaintingOrder())
                 element.Paint(graphics, FullGraph ? NodeDrawingStyle.PrintStyle : IconsOnly ? NodeDrawingStyle.IconsOnly : (visibleElements > NodeCountForSimpleView || ViewScale < 0.2) ? NodeDrawingStyle.Simple : NodeDrawingStyle.Regular); //if viewscale is 0.2, then the text, images, etc being drawn are ~1/5th the size: aka: ~6x6 pixel images, etc. Use simple draw. Also simple draw if too many objects
+
+            if (currentDragOperation == DragOperation.DrawShape && !FullGraph && SelectionZone.Width > 0 && SelectionZone.Height > 0) {
+                drawShapePen.Width = 2 / ViewScale;
+                graphics.DrawRectangle(drawShapePen, SelectionZone);
+            }
 
             //selection zone
             if (currentDragOperation == DragOperation.Selection && !FullGraph) {
@@ -725,6 +738,7 @@ namespace Foreman {
             nodeElements.Clear();
             linkElementDictionary.Clear();
             linkElements.Clear();
+            ClearAnnotations();
             selectedNodes.Clear();
             Invalidate();
         }
@@ -803,20 +817,29 @@ namespace Foreman {
             mouseDownStartScreenPoint = Control.MousePosition;
             Point graph_location = ScreenToGraph(e.Location);
 
-            GraphElement? clickedElement = (GraphElement?)draggedLinkElement ?? GetNodeAtPoint(ScreenToGraph(e.Location));
+            GraphElement? clickedElement = (GraphElement?)draggedLinkElement
+                ?? (GraphElement?)GetNodeAtPoint(graph_location)
+                ?? GetAnnotationAtPoint(graph_location);
+
+            // Before element MouseDown — that sets MouseDownElement and the modal dialog can swallow MouseUp.
+            if (Annotation_OnMouseDownDoubleClick(e, clickedElement))
+                return;
+
+            if (Annotation_OnMouseDown(e, graph_location, ref clickedElement))
+                return;
+
             clickedElement?.MouseDown(graph_location, e.Button);
 
             if (e.Button == MouseButtons.Middle || (e.Button == MouseButtons.Right)) {
                 ViewDragOriginPoint = graph_location;
-            } else if (e.Button == MouseButtons.Left && clickedElement == null) //selection
-              {
+            } else if (e.Button == MouseButtons.Left && clickedElement is not AnnotationElement) {
                 SelectionZoneOriginPoint = graph_location;
                 SelectionZone = new Rectangle();
-                if ((Control.ModifierKeys & Keys.Control) == 0 && (Control.ModifierKeys & Keys.Alt) == 0) //clear all selected nodes if we arent using modifier keys
-                {
+                if ((Control.ModifierKeys & Keys.Control) == 0 && (Control.ModifierKeys & Keys.Alt) == 0) {
                     foreach (BaseNodeElement ne in selectedNodes)
                         ne.Highlighted = false;
                     selectedNodes.Clear();
+                    ClearAnnotationSelection();
                 }
             }
         }
@@ -826,7 +849,9 @@ namespace Foreman {
 
             ToolTipRenderer.ClearFloatingControls();
             Point graph_location = ScreenToGraph(e.Location);
-            GraphElement? element = (GraphElement?)draggedLinkElement ?? GetNodeAtPoint(graph_location);
+            GraphElement? element = (GraphElement?)draggedLinkElement
+                ?? (GraphElement?)GetNodeAtPoint(graph_location)
+                ?? GetAnnotationAtPoint(graph_location);
 
             switch (e.Button) {
                 case MouseButtons.Right:
@@ -846,6 +871,7 @@ namespace Foreman {
                             new EventHandler((o, ee) => {
                                 AddNewNode(screenPoint, new ItemQualityPair("adding disconnected recipe"), ScreenToGraph(e.Location), NewNodeType.Disconnected);
                             })));
+                        Annotation_AppendContextMenuItems(graph_location);
                         rightClickMenu.Show(this, e.Location);
                     } else if (currentDragOperation != DragOperation.Selection)
                         element?.MouseUp(graph_location, e.Button, (currentDragOperation == DragOperation.Item));
@@ -854,6 +880,12 @@ namespace Foreman {
                     viewBeingDragged = false;
                     break;
                 case MouseButtons.Left:
+                    if (Annotation_FinishDrawShape()) {
+                        currentDragOperation = DragOperation.None;
+                        MouseDownElement = null;
+                        break;
+                    }
+
                     //finished selecting the given zone (process selected nodes)
                     if (currentDragOperation == DragOperation.Selection) {
                         if ((Control.ModifierKeys & Keys.Alt) != 0) //removal zone processing
@@ -864,6 +896,7 @@ namespace Foreman {
                             selectedNodes.UnionWith(currentSelectionNodes);
                         }
                         currentSelectionNodes.Clear();
+                        CommitAnnotationLassoSelection();
                     }
                     //this is a release of a left click (non-drag operation) -> modify selection if clicking on node & using modifier keys
                     else if (currentDragOperation == DragOperation.None && MouseDownElement is BaseNodeElement clickedNode) {
@@ -887,9 +920,11 @@ namespace Foreman {
                           {
                             clickedNode.MouseUp(graph_location, e.Button, false);
                         }
-                    } else if (!viewBeingDragged)
-                        element?.MouseUp(graph_location, e.Button, (currentDragOperation == DragOperation.Item));
-
+                    } else {
+                        Annotation_OnMouseUpLeft(graph_location, element, viewBeingDragged);
+                        if (!viewBeingDragged)
+                            element?.MouseUp(graph_location, e.Button, (currentDragOperation == DragOperation.Item));
+                    }
 
                     currentDragOperation = DragOperation.None;
                     MouseDownElement = null;
@@ -902,8 +937,7 @@ namespace Foreman {
 
             Point graph_location = ScreenToGraph(e.Location);
 
-            if (currentDragOperation != DragOperation.Selection) //dont care about element mouse move operations during selection operation
-            {
+            if (currentDragOperation != DragOperation.Selection && currentDragOperation != DragOperation.DrawShape) {
                 GraphElement? element = (GraphElement?)draggedLinkElement ?? MouseDownElement;
                 element?.MouseMoved(graph_location);
             }
@@ -915,30 +949,35 @@ namespace Foreman {
                         if ((downButtons & MouseButtons.Middle) == MouseButtons.Middle || (downButtons & MouseButtons.Right) == MouseButtons.Right)
                             viewBeingDragged = true;
 
-                        if (MouseDownElement != null) //there is an item under the mouse during drag
+                        if (MouseDownElement != null && !inDrawShapeMode)
                             currentDragOperation = DragOperation.Item;
                         else if ((downButtons & MouseButtons.Left) != 0)
-                            currentDragOperation = DragOperation.Selection;
+                            currentDragOperation = inDrawShapeMode ? DragOperation.DrawShape : DragOperation.Selection;
                     }
                     break;
 
                 case DragOperation.Item:
                     if (MouseDownElement is GraphElement dragTarget) {
-                        if (dragTarget is BaseNodeElement groupDragNode && selectedNodes.Contains(groupDragNode)) //dragging a group
-                        {
+                        if (dragTarget is BaseNodeElement groupDragNode && selectedNodes.Contains(groupDragNode)) {
                             Point startPoint = groupDragNode.Location;
                             GraphElement element = groupDragNode;
                             dragTarget.Dragged(graph_location);
-                            if (element == groupDragNode) //check to ensure that the dragged operation hasnt changed the mousedown element -> as is the case with item tab to dragged link
-                            {
+                            if (element == groupDragNode) {
                                 Point endPoint = groupDragNode.Location;
-                                if (startPoint != endPoint)
+                                if (startPoint != endPoint) {
+                                    int dx = endPoint.X - startPoint.X;
+                                    int dy = endPoint.Y - startPoint.Y;
                                     foreach (BaseNodeElement node in selectedNodes.Where(node => node != groupDragNode))
-                                        node.SetLocation(new Point(node.X + endPoint.X - startPoint.X, node.Y + endPoint.Y - startPoint.Y));
+                                        node.SetLocation(new Point(node.X + dx, node.Y + dy));
+                                    foreach (AnnotationElement ann in selectedAnnotations)
+                                        ann.Location = new Point(ann.X + dx, ann.Y + dy);
+                                }
                                 Invalidate();
                             }
-                        } else //dragging single item
-                          {
+                        } else if (dragTarget is AnnotationElement) {
+                            Annotation_OnItemDrag(graph_location);
+                            Invalidate();
+                        } else {
                             dragTarget.Dragged(graph_location);
                             Invalidate();
                         }
@@ -949,12 +988,20 @@ namespace Foreman {
                         viewBeingDragged = true;
                     break;
 
+                case DragOperation.DrawShape:
+                    SelectionZone = new Rectangle(
+                        Math.Min(SelectionZoneOriginPoint.X, graph_location.X),
+                        Math.Min(SelectionZoneOriginPoint.Y, graph_location.Y),
+                        Math.Abs(SelectionZoneOriginPoint.X - graph_location.X),
+                        Math.Abs(SelectionZoneOriginPoint.Y - graph_location.Y));
+                    break;
+
                 case DragOperation.Selection:
                     SelectionZone = new Rectangle(Math.Min(SelectionZoneOriginPoint.X, graph_location.X), Math.Min(SelectionZoneOriginPoint.Y, graph_location.Y), Math.Abs(SelectionZoneOriginPoint.X - graph_location.X), Math.Abs(SelectionZoneOriginPoint.Y - graph_location.Y));
                     currentSelectionNodes.Clear();
                     currentSelectionNodes.UnionWith(nodeElements.Where(element => element.IntersectsWithZone(SelectionZone, -20, -20)));
-
                     UpdateSelection();
+                    UpdateAnnotationLassoPreview();
 
                     //accept middle mouse button for view dragging purposes (while dragging item or selection)
                     if ((downButtons & MouseButtons.Middle) == MouseButtons.Middle)
@@ -968,6 +1015,7 @@ namespace Foreman {
                 UpdateGraphBounds(MouseDownElement == null); //only hard limit the graph bounds if we arent dragging an object
             }
 
+            Annotation_UpdateCursor(graph_location);
             Invalidate();
         }
 
@@ -995,6 +1043,10 @@ namespace Foreman {
         }
 
         private void ProductionGraphViewer_KeyDown(object? sender, KeyEventArgs e) {
+            Annotation_OnKeyDown(e);
+            if (e.Handled)
+                return;
+
             if (currentDragOperation == DragOperation.None) {
                 if ((e.KeyCode == Keys.C || e.KeyCode == Keys.X) && (e.Modifiers & Keys.Control) == Keys.Control) //copy or cut
                 {
@@ -1006,19 +1058,31 @@ namespace Foreman {
                     Graph.SerializeNodeIdSet.Clear();
                     Graph.SerializeNodeIdSet = null;
 
+                    if (selectedAnnotations.Count > 0) {
+                        fragmentJson = AnnotationClipboardCodec.MergeAnnotationsIntoFragment(
+                            fragmentJson,
+                            selectedAnnotations.Select(a => a.ToSaveData()));
+                    }
+
                     Clipboard.SetText(fragmentJson);
 
-                    if (e.KeyCode == Keys.X) //cut
+                    if (e.KeyCode == Keys.X) {
                         foreach (BaseNodeElement node in selectedNodes.ToList())
                             Session.Editor.DeleteNode(node.ViewModel.Id);
+                        foreach (AnnotationElement ann in selectedAnnotations.ToList())
+                            RemoveAnnotationElement(ann);
+                        selectedAnnotations.Clear();
+                    }
                 } else if (e.KeyCode == Keys.V && (e.Modifiers & Keys.Control) == Keys.Control) //paste
                   {
                     try {
                         ImportNodesFromFragment(Clipboard.GetText(), ScreenToGraph(PointToClient(Cursor.Position)), applySolverSettings: false);
                     } catch (Exception ex) { ErrorLogging.LogException(ex, "Non-Foreman paste or invalid clipboard JSON"); }
                 }
-            } else if (currentDragOperation == DragOperation.Selection) //possible changes to selection type
+            } else if (currentDragOperation == DragOperation.Selection) {
                 UpdateSelection();
+                UpdateAnnotationLassoPreview();
+            }
 
             bool lockDragAxis = (Control.ModifierKeys & Keys.Shift) != 0;
             if (Grid.LockDragToAxis != lockDragAxis) {
@@ -1034,12 +1098,17 @@ namespace Foreman {
             if (currentDragOperation == DragOperation.None) {
                 switch (e.KeyCode) {
                     case Keys.Delete:
-                        TryDeleteSelectedNodes();
+                        if (selectedAnnotations.Count > 0)
+                            TryDeleteSelection();
+                        else
+                            TryDeleteSelectedNodes();
                         e.Handled = true;
                         break;
                 }
-            } else if (currentDragOperation == DragOperation.Selection) //possible changes to selection type
+            } else if (currentDragOperation == DragOperation.Selection) {
                 UpdateSelection();
+                UpdateAnnotationLassoPreview();
+            }
 
             bool lockDragAxis = (Control.ModifierKeys & Keys.Shift) != 0;
             if (Grid.LockDragToAxis != lockDragAxis) {
@@ -1065,15 +1134,19 @@ namespace Foreman {
             }
 
             if ((keyData & Keys.KeyCode) == Keys.Left) {
+                Annotation_MoveSelection(-moveUnit, 0);
                 foreach (BaseNodeElement node in selectedNodes)
                     node.SetLocation(new Point(node.X - moveUnit, node.Y));
             } else if ((keyData & Keys.KeyCode) == Keys.Right) {
+                Annotation_MoveSelection(moveUnit, 0);
                 foreach (BaseNodeElement node in selectedNodes)
                     node.SetLocation(new Point(node.X + moveUnit, node.Y));
             } else if ((keyData & Keys.KeyCode) == Keys.Up) {
+                Annotation_MoveSelection(0, -moveUnit);
                 foreach (BaseNodeElement node in selectedNodes)
                     node.SetLocation(new Point(node.X, node.Y - moveUnit));
             } else if ((keyData & Keys.KeyCode) == Keys.Down) {
+                Annotation_MoveSelection(0, moveUnit);
                 foreach (BaseNodeElement node in selectedNodes)
                     node.SetLocation(new Point(node.X, node.Y + moveUnit));
             } else if ((keyData & Keys.KeyCode) == Keys.W && !SubwindowOpen) {
@@ -1202,6 +1275,9 @@ namespace Foreman {
                 return;
             }
             ImportNodesFromDocument(document, origin, applySolverSettings);
+
+            if (AnnotationClipboardCodec.ReadAnnotations(json) is IReadOnlyList<AnnotationSaveData> clipboardAnnotations)
+                ImportAnnotationsAtOrigin(clipboardAnnotations, origin);
         }
 
         public void ImportNodesFromDocument(ProductionGraphSaveDocument document, Point origin, bool applySolverSettings) {
@@ -1391,6 +1467,8 @@ namespace Foreman {
 
             if (saveDocument.Ui is not null)
                 ApplySaveUi(saveDocument.Ui, cache, setEnablesFromJson);
+
+            LoadAnnotationsFromSave(saveDocument.Annotations, saveDocument.AnnotationDpi);
 
             ProductionGraph.NewNodeCollection collection = GraphSaveLoader.LoadProductionGraph(Graph, cache, productionGraph, applySolverSettings: true);
             if (collection.newNodes.Count == 0 && productionGraph.Nodes.Count > 0) {

--- a/Foreman/Properties/Settings.Designer.cs
+++ b/Foreman/Properties/Settings.Designer.cs
@@ -430,5 +430,85 @@ namespace Foreman.Properties {
                 this["UpgradeRequired"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Segoe UI")]
+        public string AnnotTextFontFamily {
+            get { return ((string)(this["AnnotTextFontFamily"])); }
+            set { this["AnnotTextFontFamily"] = value; }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("14")]
+        public string AnnotTextFontSize {
+            get { return ((string)(this["AnnotTextFontSize"])); }
+            set { this["AnnotTextFontSize"] = value; }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("1")]
+        public int AnnotTextFontStyle {
+            get { return ((int)(this["AnnotTextFontStyle"])); }
+            set { this["AnnotTextFontStyle"] = value; }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("-16777216")]
+        public int AnnotTextColorARGB {
+            get { return ((int)(this["AnnotTextColorARGB"])); }
+            set { this["AnnotTextColorARGB"] = value; }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int AnnotTextBackColorARGB {
+            get { return ((int)(this["AnnotTextBackColorARGB"])); }
+            set { this["AnnotTextBackColorARGB"] = value; }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("1")]
+        public int AnnotTextAlign {
+            get { return ((int)(this["AnnotTextAlign"])); }
+            set { this["AnnotTextAlign"] = value; }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int AnnotShapeType {
+            get { return ((int)(this["AnnotShapeType"])); }
+            set { this["AnnotShapeType"] = value; }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("5278975")]
+        public int AnnotShapeFillColorARGB {
+            get { return ((int)(this["AnnotShapeFillColorARGB"])); }
+            set { this["AnnotShapeFillColorARGB"] = value; }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("-600016676")]
+        public int AnnotShapeBorderColorARGB {
+            get { return ((int)(this["AnnotShapeBorderColorARGB"])); }
+            set { this["AnnotShapeBorderColorARGB"] = value; }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("2")]
+        public int AnnotShapeBorderWidth {
+            get { return ((int)(this["AnnotShapeBorderWidth"])); }
+            set { this["AnnotShapeBorderWidth"] = value; }
+        }
     }
 }

--- a/Foreman/Properties/Settings.settings
+++ b/Foreman/Properties/Settings.settings
@@ -104,5 +104,35 @@
     <Setting Name="UpgradeRequired" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="AnnotTextFontFamily" Type="System.String" Scope="User">
+      <Value Profile="(Default)">Segoe UI</Value>
+    </Setting>
+    <Setting Name="AnnotTextFontSize" Type="System.String" Scope="User">
+      <Value Profile="(Default)">14</Value>
+    </Setting>
+    <Setting Name="AnnotTextFontStyle" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">1</Value>
+    </Setting>
+    <Setting Name="AnnotTextColorARGB" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">-16777216</Value>
+    </Setting>
+    <Setting Name="AnnotTextBackColorARGB" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="AnnotTextAlign" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">1</Value>
+    </Setting>
+    <Setting Name="AnnotShapeType" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="AnnotShapeFillColorARGB" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">5278975</Value>
+    </Setting>
+    <Setting Name="AnnotShapeBorderColorARGB" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">-600016676</Value>
+    </Setting>
+    <Setting Name="AnnotShapeBorderWidth" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">2</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Foreman/Serialization/AnnotationJson.cs
+++ b/Foreman/Serialization/AnnotationJson.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Foreman {
+    /// <summary>JSON serialization for <see cref="AnnotationSaveData"/> (save files and clipboard).</summary>
+    public static class AnnotationJson {
+        public static AnnotationSaveData? Deserialize(JsonNode node) {
+            try {
+                return node.Deserialize<AnnotationSaveData>(GraphSaveJsonOptions.Get(writeIndented: false));
+            } catch (JsonException) {
+                return null;
+            }
+        }
+
+        public static IReadOnlyList<AnnotationSaveData> DeserializeList(JsonArray array) =>
+            array.OfType<JsonNode>().Select(static item => Deserialize(item)).OfType<AnnotationSaveData>().ToList();
+
+        public static IReadOnlyList<AnnotationSaveData>? DeserializeListFromRoot(JsonNode? root, string propertyName = "Annotations") {
+            if (root?[propertyName] is not JsonArray array || array.Count == 0)
+                return null;
+            IReadOnlyList<AnnotationSaveData> list = DeserializeList(array);
+            return list.Count > 0 ? list : null;
+        }
+
+        public static JsonNode? SerializeToNode(AnnotationSaveData data) =>
+            JsonSerializer.SerializeToNode(data, typeof(AnnotationSaveData), GraphSaveJsonOptions.Get(writeIndented: false));
+
+        public static JsonArray SerializeToArray(IEnumerable<AnnotationSaveData> annotations) =>
+            new([.. annotations.Select(SerializeToNode).OfType<JsonNode>()]);
+    }
+}

--- a/Foreman/Serialization/AnnotationSaveData.cs
+++ b/Foreman/Serialization/AnnotationSaveData.cs
@@ -1,0 +1,44 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Foreman {
+    public sealed class ColorSaveData(byte a, byte r, byte g, byte b) {
+        public byte A { get; } = a;
+        public byte R { get; } = r;
+        public byte G { get; } = g;
+        public byte B { get; } = b;
+    }
+
+    [JsonPolymorphic(TypeDiscriminatorPropertyName = "Type")]
+    [JsonDerivedType(typeof(TextAnnotationSaveData), "Text")]
+    [JsonDerivedType(typeof(ShapeAnnotationSaveData), "Shape")]
+    public abstract class AnnotationSaveData {
+        /// <summary>Discriminator for JSON; written by <see cref="JsonPolymorphicAttribute"/>, not duplicated as a normal property.</summary>
+        [JsonIgnore]
+        public string Type => this switch {
+            TextAnnotationSaveData => "Text",
+            ShapeAnnotationSaveData => "Shape",
+            _ => ""
+        };
+        public int X { get; init; }
+        public int Y { get; init; }
+        public int Width { get; init; }
+        public int Height { get; init; }
+    }
+
+    public sealed class TextAnnotationSaveData : AnnotationSaveData {
+        public string Text { get; init; } = "";
+        public string FontFamily { get; init; } = "Segoe UI";
+        public float FontSize { get; init; } = 14f;
+        public int FontStyle { get; init; }
+        public ColorSaveData TextColor { get; init; } = new(255, 0, 0, 0);
+        public ColorSaveData BackColor { get; init; } = new(0, 255, 255, 255);
+        public int TextAlign { get; init; } = 1;
+    }
+
+    public sealed class ShapeAnnotationSaveData : AnnotationSaveData {
+        public string ShapeType { get; init; } = "Rectangle";
+        public ColorSaveData FillColor { get; init; } = new(80, 80, 160, 255);
+        public ColorSaveData BorderColor { get; init; } = new(255, 60, 120, 220);
+        public int BorderWidth { get; init; } = 2;
+    }
+}

--- a/Foreman/Serialization/GraphSaveDocuments.cs
+++ b/Foreman/Serialization/GraphSaveDocuments.cs
@@ -123,6 +123,8 @@ namespace Foreman {
         public IReadOnlyDictionary<string, string> IncludedMods { get; init; } = new Dictionary<string, string>();
         public required ProductionGraphSaveDocument ProductionGraph { get; init; }
         public GraphViewerUiSaveData? Ui { get; init; }
+        public IReadOnlyList<AnnotationSaveData> Annotations { get; init; } = [];
+        public int AnnotationDpi { get; init; } = 96;
     }
 
     public sealed class NodeCopyOptionsSaveDocument {

--- a/Foreman/Serialization/GraphSaveFormat.cs
+++ b/Foreman/Serialization/GraphSaveFormat.cs
@@ -2,7 +2,10 @@
     /// <summary>JSON property names and object-type markers for Foreman graph save files.</summary>
     public static class GraphSaveFormat {
         /// <summary>Current .fjson schema version written by this build. Bump when the on-disk format changes.</summary>
-        public const int SaveFormatVersion = 7;
+        public const int SaveFormatVersion = 8;
+
+        /// <summary>Oldest viewer/graph save version this build can still read.</summary>
+        public const int MinReadableSaveVersion = 7;
 
         public const string ViewerObject = "ProductionGraphViewer";
         public const string GraphObject = "ProductionGraph";

--- a/Foreman/Serialization/GraphSaveMigration.cs
+++ b/Foreman/Serialization/GraphSaveMigration.cs
@@ -1,16 +1,20 @@
 ﻿using System.Text.Json;
 
 namespace Foreman {
-    /// <summary>Validates that graph save JSON matches <see cref="GraphSaveFormat.SaveFormatVersion"/>. Invalid JSON returns false without logging (caller treats as unsupported format).</summary>
+    /// <summary>Validates that graph save JSON is a supported version. Invalid JSON returns false without logging (caller treats as unsupported format).</summary>
     internal static class GraphSaveMigration {
+        private static bool IsReadableVersion(int version) =>
+            version >= GraphSaveFormat.MinReadableSaveVersion
+            && version <= GraphSaveFormat.SaveFormatVersion;
+
         internal static bool IsCurrentGraph(string json) =>
             TryGetRootMetadata(json, out int version, out string? objectType)
-            && version == GraphSaveFormat.SaveFormatVersion
+            && IsReadableVersion(version)
             && objectType == GraphSaveFormat.GraphObject;
 
         internal static bool IsCurrentViewer(string json) {
             if (!TryGetRootMetadata(json, out int version, out string? objectType)
-                || version != GraphSaveFormat.SaveFormatVersion
+                || !IsReadableVersion(version)
                 || objectType != GraphSaveFormat.ViewerObject)
                 return false;
 
@@ -22,7 +26,7 @@ namespace Foreman {
 
                 if (!graph.TryGetProperty("Version", out JsonElement graphVersion)
                     || graphVersion.ValueKind != JsonValueKind.Number
-                    || graphVersion.GetInt32() != GraphSaveFormat.SaveFormatVersion)
+                    || !IsReadableVersion(graphVersion.GetInt32()))
                     return false;
 
                 return graph.TryGetProperty("Object", out JsonElement graphObject)

--- a/Foreman/Serialization/GraphSaveWireMapper.cs
+++ b/Foreman/Serialization/GraphSaveWireMapper.cs
@@ -37,6 +37,10 @@ namespace Foreman {
             };
             if (document.Ui is not null)
                 ApplyUi(wire, document.Ui);
+            if (document.Annotations.Count > 0) {
+                wire.Annotations = document.Annotations.ToList();
+                wire.AnnotationDpi = document.AnnotationDpi;
+            }
             return wire;
         }
 
@@ -90,7 +94,9 @@ namespace Foreman {
                 SavedPresetName = wire.SavedPresetName,
                 IncludedMods = ParseModList(wire.IncludedMods),
                 ProductionGraph = ToProductionGraphDocument(wire.ProductionGraph),
-                Ui = ToViewerUi(wire)
+                Ui = ToViewerUi(wire),
+                Annotations = wire.Annotations ?? [],
+                AnnotationDpi = wire.AnnotationDpi ?? 96
             };
         }
 
@@ -381,5 +387,6 @@ namespace Foreman {
                 return new Point(x, y);
             return Point.Empty;
         }
+
     }
 }

--- a/Foreman/Serialization/GraphSaveWireModels.cs
+++ b/Foreman/Serialization/GraphSaveWireModels.cs
@@ -42,6 +42,8 @@ namespace Foreman {
         public List<string>? EnabledBeacons { get; set; }
         public bool OldImport { get; set; }
         public ProductionGraphWire? ProductionGraph { get; set; }
+        public List<AnnotationSaveData>? Annotations { get; set; }
+        public int? AnnotationDpi { get; set; }
     }
 
     internal sealed class NodeCopyOptionsWire {

--- a/Foreman/Serialization/GraphSaveWriter.cs
+++ b/Foreman/Serialization/GraphSaveWriter.cs
@@ -31,7 +31,9 @@ namespace Foreman {
                 SavedPresetName = cache.PresetName,
                 IncludedMods = new Dictionary<string, string>(cache.IncludedMods),
                 ProductionGraph = WriteProductionGraph(viewer.Graph),
-                Ui = WriteViewerUi(viewer, cache)
+                Ui = WriteViewerUi(viewer, cache),
+                Annotations = viewer.GetAnnotationSaveData(),
+                AnnotationDpi = viewer.DeviceDpi
             };
         }
 

--- a/ForemanTest/Annotations/AnnotationClipboardCodecTests.cs
+++ b/ForemanTest/Annotations/AnnotationClipboardCodecTests.cs
@@ -1,0 +1,66 @@
+﻿using Foreman;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ForemanTest.Annotations {
+    [TestClass]
+    public class AnnotationClipboardCodecTests {
+        [TestMethod]
+        public void ReadAnnotations_RoundTripsWirePayload() {
+            var original = new TextAnnotationSaveData {
+                X = 10,
+                Y = 20,
+                Width = 120,
+                Height = 40,
+                Text = "Note",
+                FontFamily = "Segoe UI",
+                FontSize = 12f
+            };
+            string json = AnnotationClipboardCodec.MergeAnnotationsIntoFragment("{}", [original]);
+
+            IReadOnlyList<AnnotationSaveData>? restored = AnnotationClipboardCodec.ReadAnnotations(json);
+
+            Assert.IsNotNull(restored);
+            var text = restored.OfType<TextAnnotationSaveData>().Single();
+            Assert.AreEqual("Note", text.Text);
+            Assert.AreEqual(10, text.X);
+        }
+
+        [TestMethod]
+        public void ReadAnnotations_MissingArray_ReturnsNull() {
+            Assert.IsNull(AnnotationClipboardCodec.ReadAnnotations("{\"Object\":\"ProductionGraph\"}"));
+        }
+
+        [TestMethod]
+        public void MergeAnnotationsIntoFragment_AddsAnnotationsArray() {
+            string fragment = "{\"Object\":\"ProductionGraph\",\"Version\":8,\"Nodes\":[]}";
+            var annotation = new ShapeAnnotationSaveData {
+                X = 1,
+                Y = 2,
+                Width = 30,
+                Height = 40,
+                ShapeType = "Rectangle"
+            };
+
+            string merged = AnnotationClipboardCodec.MergeAnnotationsIntoFragment(
+                fragment,
+                [annotation]);
+
+            IReadOnlyList<AnnotationSaveData>? restored = AnnotationClipboardCodec.ReadAnnotations(merged);
+            Assert.IsNotNull(restored);
+            Assert.AreEqual(1, restored.Count);
+            Assert.IsInstanceOfType(restored[0], typeof(ShapeAnnotationSaveData));
+        }
+
+        [TestMethod]
+        public void MergeAnnotationsIntoFragment_InvalidJson_ReturnsOriginal() {
+            const string invalid = "not json";
+            string merged = AnnotationClipboardCodec.MergeAnnotationsIntoFragment(
+                invalid,
+                [new TextAnnotationSaveData { X = 0, Y = 0, Width = 1, Height = 1 }]);
+
+            Assert.AreEqual(invalid, merged);
+        }
+    }
+}

--- a/ForemanTest/Annotations/AnnotationJsonTests.cs
+++ b/ForemanTest/Annotations/AnnotationJsonTests.cs
@@ -1,0 +1,76 @@
+﻿using Foreman;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+
+namespace ForemanTest.Annotations {
+    [TestClass]
+    public class AnnotationJsonTests {
+        [TestMethod]
+        public void SerializeDeserialize_TextAnnotation_RoundTrips() {
+            var original = new TextAnnotationSaveData {
+                X = 12,
+                Y = 34,
+                Width = 100,
+                Height = 50,
+                Text = "Label",
+                FontFamily = "Arial",
+                FontSize = 16f,
+                FontStyle = 1,
+                TextColor = new ColorSaveData(255, 10, 20, 30),
+                BackColor = new ColorSaveData(128, 40, 50, 60),
+                TextAlign = 2
+            };
+
+            JsonNode? node = AnnotationJson.SerializeToNode(original);
+            Assert.IsNotNull(node);
+            Assert.AreEqual("Text", node["Type"]?.GetValue<string>());
+
+            AnnotationSaveData? restored = AnnotationJson.Deserialize(node);
+            Assert.IsInstanceOfType(restored, typeof(TextAnnotationSaveData));
+            var text = (TextAnnotationSaveData)restored;
+            Assert.AreEqual("Label", text.Text);
+            Assert.AreEqual(12, text.X);
+            Assert.AreEqual(16f, text.FontSize);
+            Assert.AreEqual(30, text.TextColor.B);
+        }
+
+        [TestMethod]
+        public void SerializeDeserialize_ShapeAnnotation_RoundTrips() {
+            var original = new ShapeAnnotationSaveData {
+                X = 1,
+                Y = 2,
+                Width = 80,
+                Height = 90,
+                ShapeType = "Ellipse",
+                FillColor = new ColorSaveData(80, 1, 2, 3),
+                BorderColor = new ColorSaveData(255, 4, 5, 6),
+                BorderWidth = 3
+            };
+
+            AnnotationSaveData? restored = AnnotationJson.Deserialize(AnnotationJson.SerializeToNode(original)!);
+            Assert.IsInstanceOfType(restored, typeof(ShapeAnnotationSaveData));
+            var shape = (ShapeAnnotationSaveData)restored;
+            Assert.AreEqual("Ellipse", shape.ShapeType);
+            Assert.AreEqual(3, shape.BorderWidth);
+        }
+
+        [TestMethod]
+        public void DeserializeListFromRoot_UnknownType_SkipsEntry() {
+            var root = JsonNode.Parse("""
+                {
+                  "Annotations": [
+                    { "Type": "Text", "X": 0, "Y": 0, "Width": 10, "Height": 10, "Text": "ok" },
+                    { "Type": "Unknown", "X": 0, "Y": 0, "Width": 1, "Height": 1 }
+                  ]
+                }
+                """);
+
+            IReadOnlyList<AnnotationSaveData>? list = AnnotationJson.DeserializeListFromRoot(root);
+            Assert.IsNotNull(list);
+            Assert.AreEqual(1, list.Count);
+            Assert.IsInstanceOfType(list[0], typeof(TextAnnotationSaveData));
+        }
+    }
+}

--- a/ForemanTest/Annotations/GraphExportBoundsTests.cs
+++ b/ForemanTest/Annotations/GraphExportBoundsTests.cs
@@ -1,0 +1,85 @@
+﻿using Foreman;
+using ForemanTest.support;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+
+namespace ForemanTest.Annotations {
+    [TestClass]
+    public class GraphExportBoundsTests {
+        [TestMethod]
+        public void Compute_EmptyGraphAndNoAnnotations_ReturnsEmpty() {
+            Rectangle result = GraphExportBounds.Compute(Rectangle.Empty, []);
+
+            Assert.AreEqual(Rectangle.Empty, result);
+            Assert.IsFalse(GraphExportBounds.IsExportable(result));
+        }
+
+        [TestMethod]
+        public void Compute_GraphOnly_ReturnsGraphBounds() {
+            Rectangle graph = new(10, 20, 400, 300);
+
+            Rectangle result = GraphExportBounds.Compute(graph, []);
+
+            Assert.AreEqual(graph, result);
+        }
+
+        [TestMethod]
+        public void Compute_AnnotationsOnly_IncludesPadding() {
+            Rectangle annotation = new(100, 50, 80, 40);
+
+            Rectangle result = GraphExportBounds.Compute(Rectangle.Empty, [annotation]);
+
+            Assert.AreEqual(annotation.Left - GraphExportBounds.AnnotationOnlyPadding, result.Left);
+            Assert.AreEqual(annotation.Top - GraphExportBounds.AnnotationOnlyPadding, result.Top);
+            Assert.IsTrue(GraphExportBounds.IsExportable(result));
+        }
+
+        [TestMethod]
+        public void Compute_AnnotationOutsideGraph_ExpandsBounds() {
+            Rectangle graph = new(0, 0, 200, 200);
+            Rectangle annotation = new(300, 0, 50, 50);
+
+            Rectangle result = GraphExportBounds.Compute(graph, [annotation]);
+
+            Assert.AreEqual(0, result.Left);
+            Assert.AreEqual(0, result.Top);
+            Assert.AreEqual(350, result.Width);
+            Assert.AreEqual(200, result.Height);
+        }
+
+        [TestMethod]
+        public void ScaledDimensions_NeverReturnZero() {
+            Assert.AreEqual(1, GraphExportBounds.ScaledWidth(Rectangle.Empty, 1f));
+            Assert.AreEqual(1, GraphExportBounds.ScaledHeight(Rectangle.Empty, 1f));
+            Assert.AreEqual(1, GraphExportBounds.ScaledWidth(new Rectangle(0, 0, 3, 3), 0.05f));
+        }
+
+        [TestMethod]
+        public void FullGraphExport_AnnotationsOnly_DoesNotThrow() =>
+            StaTest.Run(FullGraphExport_AnnotationsOnly_DoesNotThrow_Impl);
+
+        private static void FullGraphExport_AnnotationsOnly_DoesNotThrow_Impl() {
+            using var viewer = new ProductionGraphViewer {
+                Size = new Size(800, 600),
+            };
+            viewer.AddAnnotationElement(new ShapeAnnotationElement(viewer, new Point(120, 80), 100, 60));
+
+            Rectangle exportBounds = viewer.GetExportBounds();
+            Assert.IsTrue(GraphExportBounds.IsExportable(exportBounds));
+
+            using var image = new Bitmap(
+                GraphExportBounds.ScaledWidth(exportBounds, 1f),
+                GraphExportBounds.ScaledHeight(exportBounds, 1f));
+            using var graphics = Graphics.FromImage(image);
+            graphics.ScaleTransform(1f, 1f);
+            graphics.TranslateTransform(-exportBounds.X, -exportBounds.Y);
+            viewer.Paint(graphics, true);
+
+            using var stream = new MemoryStream();
+            image.Save(stream, ImageFormat.Png);
+            Assert.IsTrue(stream.Length > 0);
+        }
+    }
+}

--- a/ForemanTest/Annotations/TextAnnotationElementTests.cs
+++ b/ForemanTest/Annotations/TextAnnotationElementTests.cs
@@ -1,0 +1,67 @@
+﻿using Foreman;
+using ForemanTest.Graph;
+using ForemanTest.support;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
+using System.Linq;
+
+namespace ForemanTest.Annotations {
+    [TestClass]
+    [DoNotParallelize]
+    public class TextAnnotationElementTests : ForemanTestBase {
+        [TestMethod]
+        public void FitBoxToTextAtCenter_PreservesCenter() =>
+            StaTest.Run(FitBoxToTextAtCenter_PreservesCenter_Impl);
+
+        [TestMethod]
+        public void SetFontSizeInPoints_GrowsBoxWhenFitted() =>
+            StaTest.Run(SetFontSizeInPoints_GrowsBoxWhenFitted_Impl);
+
+        private static void FitBoxToTextAtCenter_PreservesCenter_Impl() {
+            using var viewer = CreateViewer();
+            var annotation = new TextAnnotationElement(viewer, new Point(100, 200));
+            annotation.Text = "Hello";
+
+            int centerX = annotation.X;
+            int centerY = annotation.Y;
+            int widthBefore = annotation.Width;
+            int heightBefore = annotation.Height;
+
+            annotation.SetFontSizeInPoints(24f);
+            annotation.FitBoxToTextAtCenter();
+
+            Assert.AreEqual(centerX, annotation.X);
+            Assert.AreEqual(centerY, annotation.Y);
+            Assert.IsTrue(annotation.Width >= widthBefore);
+            Assert.IsTrue(annotation.Height >= heightBefore);
+        }
+
+        private static void SetFontSizeInPoints_GrowsBoxWhenFitted_Impl() {
+            using var viewer = CreateViewer();
+            var annotation = new TextAnnotationElement(viewer, new Point(50, 50));
+            annotation.Text = "Scale me";
+            annotation.FitBoxToTextAtCenter();
+
+            int widthAt14 = annotation.Width;
+            annotation.SetFontSizeInPoints(28f);
+            annotation.FitBoxToTextAtCenter();
+
+            Assert.IsTrue(annotation.Width > widthAt14);
+            Assert.AreEqual(28f, annotation.TextFont.SizeInPoints, 0.01f);
+        }
+
+        private static ProductionGraphViewer CreateViewer() {
+            var ctx = GraphSessionTestHelper.CreateContext();
+            var viewer = new ProductionGraphViewer {
+                DCache = ctx.Cache,
+                Size = new Size(800, 600),
+            };
+            viewer.Graph.DefaultAssemblerQuality = ctx.Quality;
+            viewer.ApplySaveUi(new GraphViewerUiSaveData {
+                ViewOffset = Point.Empty,
+                ViewScale = 1f,
+            }, ctx.Cache, setEnablesFromJson: false);
+            return viewer;
+        }
+    }
+}

--- a/ForemanTest/Annotations/TextAnnotationLayoutTests.cs
+++ b/ForemanTest/Annotations/TextAnnotationLayoutTests.cs
@@ -1,0 +1,54 @@
+﻿using Foreman;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
+
+namespace ForemanTest.Annotations {
+    [TestClass]
+    public class TextAnnotationLayoutTests {
+        [TestMethod]
+        public void MeasureBoxForText_EmptyText_ReturnsMinimumSize() {
+            using var font = new Font("Segoe UI", 14f, FontStyle.Regular, GraphicsUnit.Point);
+            Size box = TextAnnotationLayout.MeasureBoxForText("", font);
+
+            Assert.AreEqual(TextAnnotationLayout.MinBoxWidth, box.Width);
+            Assert.AreEqual(TextAnnotationLayout.MinBoxHeight, box.Height);
+        }
+
+        [TestMethod]
+        public void MeasureBoxForText_LabelText_IsLargerThanMinimum() {
+            using var font = new Font("Segoe UI", 14f, FontStyle.Bold, GraphicsUnit.Point);
+            Size box = TextAnnotationLayout.MeasureBoxForText("Hello", font);
+
+            Assert.IsTrue(box.Width > TextAnnotationLayout.MinBoxWidth);
+            Assert.IsTrue(box.Height > TextAnnotationLayout.MinBoxHeight);
+        }
+
+        [TestMethod]
+        public void ComputeResizeFontSize_DoublesBox_DoublesFont() {
+            float result = TextAnnotationLayout.ComputeResizeFontSize(14f, 100, 50, 200, 100);
+
+            Assert.AreEqual(28f, result, 0.01f);
+        }
+
+        [TestMethod]
+        public void ComputeResizeFontSize_InvalidStartSize_ReturnsStartFont() {
+            float result = TextAnnotationLayout.ComputeResizeFontSize(14f, 0, 50, 200, 100);
+
+            Assert.AreEqual(14f, result);
+        }
+
+        [TestMethod]
+        public void ComputeResizeFontSize_ClampsToMaximum() {
+            float result = TextAnnotationLayout.ComputeResizeFontSize(
+                200f, 10, 10, 1000, 1000);
+
+            Assert.AreEqual(TextAnnotationLayout.MaxFontSizePt, result);
+        }
+
+        [TestMethod]
+        public void NearlyEqualFontSize_WithinTolerance_ReturnsTrue() {
+            Assert.IsTrue(TextAnnotationLayout.NearlyEqualFontSize(14f, 14.04f));
+            Assert.IsFalse(TextAnnotationLayout.NearlyEqualFontSize(14f, 14.1f));
+        }
+    }
+}

--- a/ForemanTest/GraphSaveSerializerTests.cs
+++ b/ForemanTest/GraphSaveSerializerTests.cs
@@ -69,6 +69,56 @@ namespace ForemanTest {
         }
 
         [TestMethod]
+        public void GraphSaveCodec_Annotations_RoundTripThroughViewerDocument() {
+            var data = BuildSimpleChain();
+            var annotations = new List<AnnotationSaveData> {
+                new TextAnnotationSaveData {
+                    X = 100,
+                    Y = 200,
+                    Width = 150,
+                    Height = 40,
+                    Text = "Hello",
+                    FontFamily = "Segoe UI",
+                    FontSize = 14f,
+                    TextColor = new ColorSaveData(255, 0, 0, 0),
+                    BackColor = new ColorSaveData(0, 255, 255, 255),
+                    TextAlign = 1
+                },
+                new ShapeAnnotationSaveData {
+                    X = 50,
+                    Y = 60,
+                    Width = 200,
+                    Height = 100,
+                    ShapeType = "Ellipse",
+                    FillColor = new ColorSaveData(80, 80, 160, 255),
+                    BorderColor = new ColorSaveData(255, 60, 120, 220),
+                    BorderWidth = 2
+                }
+            };
+            GraphViewerSaveDocument original = new() {
+                Version = GraphSaveFormat.SaveFormatVersion,
+                ProductionGraph = GraphSaveCodec.BuildProductionGraph(data.Graph),
+                Annotations = annotations,
+                AnnotationDpi = 120
+            };
+
+            string json = GraphSaveCodec.WriteViewerDocumentToString(original, writeIndented: false);
+            GraphViewerSaveDocument? restored = GraphSaveCodec.ReadViewer(json);
+
+            Assert.IsNotNull(restored);
+            Assert.AreEqual(120, restored.AnnotationDpi);
+            Assert.AreEqual(2, restored.Annotations.Count);
+
+            var text = restored.Annotations.OfType<TextAnnotationSaveData>().Single();
+            Assert.AreEqual("Hello", text.Text);
+            Assert.AreEqual(100, text.X);
+
+            var shape = restored.Annotations.OfType<ShapeAnnotationSaveData>().Single();
+            Assert.AreEqual("Ellipse", shape.ShapeType);
+            Assert.AreEqual(2, shape.BorderWidth);
+        }
+
+        [TestMethod]
         public void GraphSaveCodec_ReadGraphPayload_AcceptsViewerSaveFile() {
             var data = BuildSimpleChain();
             GraphViewerSaveDocument viewerDoc = new() {

--- a/ForemanTest/assets/Flowchart.fjson
+++ b/ForemanTest/assets/Flowchart.fjson
@@ -1,5 +1,5 @@
 {
-  "Version": 7,
+  "Version": 8,
   "Object": "ProductionGraphViewer",
   "SavedPresetName": "Factorio 2.0 Space Age",
   "IncludedMods": [
@@ -678,7 +678,7 @@
     "beacon"
   ],
   "ProductionGraph": {
-    "Version": 7,
+    "Version": 8,
     "Object": "ProductionGraph",
     "EnableExtraProductivityForNonMiners": false,
     "DefaultNodeDirection": 0,


### PR DESCRIPTION
We now provide the ability to place shapes and text onto the graph. A good chunk of this functionality was lifted from https://github.com/Hobbes24/Foreman2 but underwent significant refactoring.

Additionally, the export to image feature has been altered to support displaying these annotations along with fixing a bug where exporting an empty graph would crash the program with an unhandled exception.

Tests have been added to verify the behaviour.

Closes #81