### PR TITLE
Fix dragging multiple nodes, use red/blue for science pack selection.

### DIFF
--- a/Foreman/Controls/ChooserIconGrid.cs
+++ b/Foreman/Controls/ChooserIconGrid.cs
@@ -52,6 +52,13 @@ namespace Foreman {
                         Enabled = false,
                     };
                     button.FlatAppearance.BorderSize = 1;
+                    button.BackgroundImageChanged += (sender, e) => _ = sender switch {
+                        NFButton btn => btn.FlatAppearance.BorderSize = btn.BackgroundImage switch {
+                            null => 1,
+                            _ => 0,
+                        },
+                        _ => default,
+                    };
                     buttons[column][row] = button;
                     gridSurface.Controls.Add(button);
                 }
@@ -135,8 +142,8 @@ namespace Foreman {
 
             for (int row = 0; row < VisibleRowCount; row++) {
                 for (int column = 0; column < ColumnCount; column++) {
-                    buttons[column][row].Bounds = new Rectangle(column * cellSize, row * cellSize, cellSize, cellSize);
-                    buttons[column][row].FlatAppearance.BorderSize = Math.Max(1, cellSize / 24);
+                    var btn = buttons[column][row];
+                    btn.Bounds = new Rectangle(column * cellSize, row * cellSize, cellSize, cellSize);
                 }
             }
         }

--- a/Foreman/Forms/SciencePacksLoadForm.cs
+++ b/Foreman/Forms/SciencePacksLoadForm.cs
@@ -10,7 +10,7 @@ using System.Windows.Forms;
 namespace Foreman {
     public partial class SciencePacksLoadForm : Form {
         private readonly Dictionary<Button, bool> SciencePackButtons;
-        private static readonly Color EnabledPackBGColor = Color.DarkGreen;
+        private static readonly Color EnabledPackBGColor = Color.DeepSkyBlue;
         private static readonly Color DisabledPackBGColor = Color.DarkRed;
         private const int IconSize = 48; //actually a bit smaller due to button padding, but whatever.
         private const int MaxColumns = 14;

--- a/Foreman/ProductionGraphView/ProductionGraphViewer.cs
+++ b/Foreman/ProductionGraphView/ProductionGraphViewer.cs
@@ -876,10 +876,13 @@ namespace Foreman {
                 SelectionZoneOriginPoint = graph_location;
                 SelectionZone = new Rectangle();
                 if ((Control.ModifierKeys & Keys.Control) == 0 && (Control.ModifierKeys & Keys.Alt) == 0) {
-                    foreach (BaseNodeElement ne in selectedNodes)
-                        ne.Highlighted = false;
-                    selectedNodes.Clear();
-                    ClearAnnotationSelection();
+                    bool keepGroupSelection = clickedElement is BaseNodeElement clickedNode && selectedNodes.Contains(clickedNode);
+                    if (!keepGroupSelection) {
+                        foreach (BaseNodeElement ne in selectedNodes)
+                            ne.Highlighted = false;
+                        selectedNodes.Clear();
+                        ClearAnnotationSelection();
+                    }
                 }
             }
         }

--- a/ForemanTest/ProductionGraphViewerEditTests.cs
+++ b/ForemanTest/ProductionGraphViewerEditTests.cs
@@ -58,6 +58,14 @@ namespace ForemanTest {
         public void EditFlowPanel_HeightFitsShortViewer() =>
             StaTest.Run(EditFlowPanel_HeightFitsShortViewer_Impl);
 
+        [TestMethod]
+        public void MouseDown_OnAlreadySelectedNode_PreservesMultiSelection() =>
+            StaTest.Run(MouseDown_OnAlreadySelectedNode_PreservesMultiSelection_Impl);
+
+        [TestMethod]
+        public void MouseDown_OnUnselectedNode_ClearsExistingSelection() =>
+            StaTest.Run(MouseDown_OnUnselectedNode_ClearsExistingSelection_Impl);
+
         private static void EditNode_DoesNotChangeViewOffset_WhenPanelsWouldClip_Impl() {
             var ctx = GraphSessionTestHelper.CreateContext();
             using var viewer = CreateViewer(ctx, lockedRecipeEditor: false, viewOffset: new Point(120, 300));
@@ -230,6 +238,49 @@ namespace ForemanTest {
             AssertFloatingPanelsOnScreen(viewer);
         }
 
+        private static void MouseDown_OnAlreadySelectedNode_PreservesMultiSelection_Impl() {
+            var ctx = GraphSessionTestHelper.CreateContext();
+            using var viewer = CreateViewer(ctx, lockedRecipeEditor: false, viewOffset: new Point(0, 0));
+
+            NodeId id1 = viewer.Session.Editor.CreateSupplierNode(ctx.Item("iron"), new Point(100, 100));
+            NodeId id2 = viewer.Session.Editor.CreateSupplierNode(ctx.Item("copper"), new Point(300, 100));
+            Assert.IsTrue(viewer.NodeElementDictionary.TryGetValue(id1, out BaseNodeElement? node1));
+            Assert.IsTrue(viewer.NodeElementDictionary.TryGetValue(id2, out BaseNodeElement? node2));
+            Assert.IsNotNull(node1);
+            Assert.IsNotNull(node2);
+
+            SetViewerSelection(viewer, node1, node2);
+            Assert.AreEqual(2, viewer.SelectedNodes.Count);
+
+            InvokeViewerMouseDown(viewer, viewer.GraphToScreen(new Point(node1.X, node1.Y)));
+
+            Assert.AreEqual(2, viewer.SelectedNodes.Count);
+            Assert.IsTrue(node1.Highlighted);
+            Assert.IsTrue(node2.Highlighted);
+        }
+
+        private static void MouseDown_OnUnselectedNode_ClearsExistingSelection_Impl() {
+            var ctx = GraphSessionTestHelper.CreateContext();
+            using var viewer = CreateViewer(ctx, lockedRecipeEditor: false, viewOffset: new Point(0, 0));
+
+            NodeId id1 = viewer.Session.Editor.CreateSupplierNode(ctx.Item("iron"), new Point(100, 100));
+            NodeId id2 = viewer.Session.Editor.CreateSupplierNode(ctx.Item("copper"), new Point(300, 100));
+            NodeId id3 = viewer.Session.Editor.CreateSupplierNode(ctx.Item("plate"), new Point(500, 100));
+            Assert.IsTrue(viewer.NodeElementDictionary.TryGetValue(id1, out BaseNodeElement? node1));
+            Assert.IsTrue(viewer.NodeElementDictionary.TryGetValue(id2, out BaseNodeElement? node2));
+            Assert.IsTrue(viewer.NodeElementDictionary.TryGetValue(id3, out BaseNodeElement? node3));
+            Assert.IsNotNull(node1);
+            Assert.IsNotNull(node2);
+            Assert.IsNotNull(node3);
+
+            SetViewerSelection(viewer, node1, node2);
+            InvokeViewerMouseDown(viewer, viewer.GraphToScreen(new Point(node3.X, node3.Y)));
+
+            Assert.AreEqual(0, viewer.SelectedNodes.Count);
+            Assert.IsFalse(node1.Highlighted);
+            Assert.IsFalse(node2.Highlighted);
+        }
+
         private static void ItemChooser_ClosesOnGraphClick_AndSelectsWithoutException_Impl() {
             var ctx = GraphSessionTestHelper.CreateContext();
             TestDataCacheHelper.SetPresetName(ctx.Cache, "test-preset");
@@ -274,6 +325,20 @@ namespace ForemanTest {
             recipe.InternalOneWayAddIngredient(ore, 1);
             recipe.InternalOneWayAddProduct(plate, 1, 0);
             return recipe;
+        }
+
+        private static void SetViewerSelection(ProductionGraphViewer viewer, params BaseNodeElement[] nodes) {
+            MethodInfo? setSelection = typeof(ProductionGraphViewer).GetMethod(
+                "SetSelection", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(setSelection);
+            setSelection.Invoke(viewer, [nodes]);
+        }
+
+        private static void InvokeViewerMouseDown(ProductionGraphViewer viewer, Point clientLocation) {
+            MethodInfo? viewerMouseDown = typeof(ProductionGraphViewer).GetMethod(
+                "ProductionGraphViewer_MouseDown", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(viewerMouseDown);
+            viewerMouseDown.Invoke(viewer, [viewer, new MouseEventArgs(MouseButtons.Left, 1, clientLocation.X, clientLocation.Y, 0)]);
         }
 
         private static ProductionGraphViewer CreateViewer(


### PR DESCRIPTION
We previously introduced a regression when adding the shape/text feature which broke dragging multiple nodes around the graph after selecting them. Tests have been added to verify the behaviour.

Additionally, when using the "Assign based on science packs" in Settings, we use blue to represent the selected state for the benefit of those with deuteranopia.

The item/recipe chooser layout has also received a very minor tweak that removed the black border around the icons.