### PR TITLE
Implement reproducible builds.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,9 @@ jobs:
         run: dotnet test --configuration Release -r win-x64
         timeout-minutes: 1
       - name: Package Foreman (Self-Contained)
-        run: dotnet publish Foreman --sc true -p:PublishSingleFile=true -o distsc -p:VersionPrefix=${{steps.tag.outputs.result}} -p:IncludeSourceRevisionInInformationalVersion=false -p:IncludeNativeLibrariesForSelfExtract=true --configuration Release -r win-x64
+        run: dotnet publish Foreman --sc -p:PublishSingleFile=true -o distsc -p:VersionPrefix=${{steps.tag.outputs.result}} -p:IncludeSourceRevisionInInformationalVersion=false -p:IncludeNativeLibrariesForSelfExtract=true --configuration Release -r win-x64
       - name: Package Foreman (.NET Dependent)
-        run: dotnet publish Foreman --sc false -p:PublishSingleFile=true -o dist -p:VersionPrefix=${{steps.tag.outputs.result}} -p:IncludeSourceRevisionInInformationalVersion=false --configuration Release -r win-x64
+        run: dotnet publish Foreman --no-self-contained -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o dist -p:VersionPrefix=${{steps.tag.outputs.result}} -p:IncludeSourceRevisionInInformationalVersion=false --configuration Release -r win-x64
       - name: Archive Foreman (Self-Contained)
         run: Compress-Archive -Path distsc/* -DestinationPath ForemanSC.zip
       - name: Archive Foreman (.NET Dependent)

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -32,7 +32,7 @@ jobs:
               }
             };
             await exec.exec('git', ['describe'], options);
-            return ret.substring(1).split('-')[0]
+            return ret.substring(1).split('-')[0].trim()
           result-encoding: string
       - name: Install .NET
         uses: actions/setup-dotnet@v5.2.0
@@ -48,9 +48,9 @@ jobs:
         run: dotnet test --configuration Release -r win-x64
         timeout-minutes: 1
       - name: Package Foreman (Self-Contained)
-        run: dotnet publish Foreman --sc true -p:PublishSingleFile=true -o distsc -p:VersionPrefix=${{steps.tag.outputs.result}} -p:VersionSuffix=SNAPSHOT -p:IncludeNativeLibrariesForSelfExtract=true --configuration Release -r win-x64
+        run: dotnet publish Foreman --sc -p:PublishSingleFile=true -o distsc -p:VersionPrefix=${{steps.tag.outputs.result}} -p:VersionSuffix=SNAPSHOT -p:IncludeNativeLibrariesForSelfExtract=true --configuration Release -r win-x64
       - name: Package Foreman (.NET Dependent)
-        run: dotnet publish Foreman --sc false -p:PublishSingleFile=true -o dist -p:VersionPrefix=${{steps.tag.outputs.result}} -p:VersionSuffix=SNAPSHOT --configuration Release -r win-x64
+        run: dotnet publish Foreman --no-self-contained -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o dist -p:VersionPrefix=${{steps.tag.outputs.result}} -p:VersionSuffix=SNAPSHOT --configuration Release -r win-x64
       - name: Archive Foreman (Self-Contained)
         uses: actions/upload-artifact@v4
         with:

--- a/Foreman/Foreman.csproj
+++ b/Foreman/Foreman.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="DotNet.ReproducibleBuilds.Isolated" Version="2.0.2" />
   <PropertyGroup>
     <TargetFramework>net10.0-windows8.0</TargetFramework>
     <OutputType>WinExe</OutputType>
@@ -35,6 +36,7 @@
     <PackageReference Include="Google.OrTools" Version="9.15.6755" />
     <PackageReference Include="Google.Protobuf" Version="3.34.1" />
     <PackageReference Include="ZstdSharp.Port" Version="0.8.8" />
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="2.0.2" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Controls\DataObjectCheckedListBox.cs">

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.300",
+    "rollForward": "minor"
+  }
+}


### PR DESCRIPTION
This commit introduces reproducible builds. This should make it possible for anyone to produce a byte-for-byte identical build by running the same commands on their machine as our GitHub Actions.

Whilst the releases we ship already come directly from GitHub Actions, this ensures that we can verify the builds in the event GitHub is compromised in some manner.

Note that the ZIP file itself is not intended to be reproducible since different systems will have a different compression implementation and it is out-of-scope to implement our own at this point. Nonetheless, all contents are 1:1 reproducible.