### PR TITLE
Fix Passthrough nodes defaulting to simplified view

### DIFF
--- a/Foreman/Models/Nodes/PassthroughNode.cs
+++ b/Foreman/Models/Nodes/PassthroughNode.cs
@@ -21,7 +21,7 @@ namespace Foreman.Models.Nodes {
         public bool SimpleDraw { get; set; }
         public PassthroughNode(ProductionGraph graph, int nodeID, ItemQualityPair item) : base(graph, nodeID) {
             PassthroughItem = item;
-            SimpleDraw = true;
+            SimpleDraw = graph.DefaultToSimplePassthroughNodes;
             controller = new PassthroughNodeController(this);
         }
 

--- a/ForemanTest/ItemQualityNodeDiagnosticsTests.cs
+++ b/ForemanTest/ItemQualityNodeDiagnosticsTests.cs
@@ -6,6 +6,7 @@ using ForemanTest.Graph;
 using ForemanTest.support;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Drawing;
 using System.Linq;
 
 namespace ForemanTest {
@@ -75,6 +76,20 @@ namespace ForemanTest {
 
             Assert.Contains("Passthrough", node.ToString());
             Assert.IsFalse(node.ToString().StartsWith("Supply node", StringComparison.Ordinal));
+        }
+
+        [TestMethod]
+        public void Passthrough_NewNode_UsesGraphDefaultSimpleDraw() {
+            var ctx = GraphSessionTestHelper.CreateContext();
+            var graph = ctx.NewGraph();
+
+            graph.DefaultToSimplePassthroughNodes = false;
+            PassthroughNode plain = graph.CreatePassthroughNode(ctx.Item("belt"), Point.Empty);
+            Assert.IsFalse(plain.SimpleDraw);
+
+            graph.DefaultToSimplePassthroughNodes = true;
+            PassthroughNode simplified = graph.CreatePassthroughNode(ctx.Item("iron"), Point.Empty);
+            Assert.IsTrue(simplified.SimpleDraw);
         }
 
         [TestMethod]


### PR DESCRIPTION
The PassthroughNode lost its default and wasn't pulling from the user's settings. This fixes it and adds a test to prevent regression.

Closes #169